### PR TITLE
feat: use tokio sleep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ reqwest = { version = "0.12.23", features = ["json"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.145"
 thiserror = "2.0.17"
+tokio = { version = "1", default-features = false, features = ["time"] }
 tracing = "0.1.41"
 
 [dev-dependencies]

--- a/src/bridge.rs
+++ b/src/bridge.rs
@@ -6,7 +6,8 @@ use alloy_provider::Provider;
 use alloy_sol_types::SolEvent;
 use bon::Builder;
 use reqwest::{Client, Response};
-use std::{thread::sleep, time::Duration};
+use std::time::Duration;
+use tokio::time::sleep;
 use tracing::{debug, error, info, instrument, trace, Level};
 
 use crate::{AttestationBytes, AttestationResponse, AttestationStatus, CctpV1};
@@ -245,7 +246,7 @@ impl<P: Provider<Ethereum> + Clone> Cctp<P> {
             if response.status() == reqwest::StatusCode::TOO_MANY_REQUESTS {
                 let secs = 5 * 60;
                 debug!(sleep_secs = secs, event = "rate_limit_exceeded");
-                sleep(Duration::from_secs(secs));
+                sleep(Duration::from_secs(secs)).await;
                 continue;
             }
 
@@ -257,7 +258,7 @@ impl<P: Provider<Ethereum> + Clone> Cctp<P> {
                     poll_interval_secs = poll_interval,
                     event = "attestation_not_found"
                 );
-                sleep(Duration::from_secs(poll_interval));
+                sleep(Duration::from_secs(poll_interval)).await;
                 continue;
             }
 
@@ -316,7 +317,7 @@ impl<P: Provider<Ethereum> + Clone> Cctp<P> {
                         poll_interval_secs = poll_interval,
                         event = "attestation_pending"
                     );
-                    sleep(Duration::from_secs(poll_interval));
+                    sleep(Duration::from_secs(poll_interval)).await;
                 }
             }
         }


### PR DESCRIPTION
# Pull Request

## Description

use tokio sleep instead of std::thread::sleep, to prevent worker thread blocking

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [X ] Performance improvement
- [ ] Code cleanup/refactoring

## Related Issues
Fixes #(issue number)

## Changes Made
-  use tokio sleep instead of std::thread::sleep, to prevent worker thread blocking

## Testing
- [ ] I have added tests that cover my changes
- [X ] All new and existing tests pass locally with my changes
- [X ] I have tested the examples and they work correctly

## Code Quality
- [ X] My code follows the style guidelines of this project
- [ X] I have performed a self-review of my own code
- [X ] I have commented my code, particularly in hard-to-understand areas
- [X ] My changes generate no new compiler warnings
- [ X] I have run `cargo clippy` and addressed any issues
- [X ] I have run `cargo fmt` to format my code



## Security
- [X ] My changes don't introduce any security vulnerabilities
- [ X] I have considered the security implications of my changes
- [ ]X I have not exposed any sensitive information (keys, tokens, etc.)

