### PR TITLE
release: v5.1.0 — expose sol!-generated contract modules for event log decoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,15 +149,16 @@ dependencies = [
 
 [[package]]
 name = "alloy-eip7928"
-version = "0.3.5"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec6ae911a2fc304a7cb80a79fb7bed6d1474aed4e7c203df1f8ff538f64fc78d"
+checksum = "6b827a6d7784fe3eb3489d40699407a4cdcce74271421a01bdffe60cf573bb16"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "borsh",
  "once_cell",
  "serde",
+ "thiserror",
 ]
 
 [[package]]
@@ -938,9 +939,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.3"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -948,9 +949,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.40.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
 dependencies = [
  "cc",
  "cmake",
@@ -1096,6 +1097,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1139,9 +1149,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.61"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1942,9 +1952,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -2259,7 +2269,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -2376,9 +2386,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.97"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -3545,11 +3555,12 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.19.0"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f05839ce67618e14a09b286535c0d9c94e85ef25469b0e13cb4f844e5593eb19"
+checksum = "e72c1c2cb7b223fafb600a619537a871c2818583d619401b785e7c0b746ccde2"
 dependencies = [
  "base64",
+ "bs58",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -3564,9 +3575,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.19.0"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf2ebbe86054f9b45bc3881e865683ccfaccce97b9b4cb53f3039d67f355a334"
+checksum = "b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -3932,9 +3943,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.2"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "110a78583f19d5cdb2c5ccf321d1290344e71313c6c37d43520d386027d18386"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -4038,9 +4049,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.9"
+version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28f0d049ccfaa566e14e9663d304d8577427b368cb4710a20528690287a738b"
+checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
 dependencies = [
  "bitflags",
  "bytes",
@@ -4272,9 +4283,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4285,9 +4296,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.70"
+version = "0.4.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af934872acec734c2d80e6617bbb5ff4f12b052dd8e6332b0817bce889516084"
+checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4295,9 +4306,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4305,9 +4316,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -4318,9 +4329,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
 dependencies = [
  "unicode-ident",
 ]
@@ -4375,9 +4386,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.97"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
+checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4809,9 +4820,9 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]

--- a/src/contracts/v2/mod.rs
+++ b/src/contracts/v2/mod.rs
@@ -9,5 +9,5 @@
 mod message_transmitter_v2;
 mod token_messenger_v2;
 
-pub use message_transmitter_v2::MessageTransmitterV2Contract;
-pub use token_messenger_v2::TokenMessengerV2Contract;
+pub use message_transmitter_v2::{MessageTransmitterV2, MessageTransmitterV2Contract};
+pub use token_messenger_v2::{TokenMessengerV2, TokenMessengerV2Contract};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,6 +125,22 @@
 //! - Contract wrappers for direct contract interaction:
 //!   - v1: [`TokenMessengerContract`], [`MessageTransmitterContract`]
 //!   - v2: [`TokenMessengerV2Contract`], [`MessageTransmitterV2Contract`]
+//! - `sol!`-generated modules for decoding raw event logs against the canonical ABI:
+//!   - v1: [`TokenMessenger`], [`MessageTransmitter`]
+//!   - v2: [`TokenMessengerV2`], [`MessageTransmitterV2`]
+//!
+//! For example, to decode a v2 `DepositForBurn` event log:
+//!
+//! ```rust,no_run
+//! use cctp_rs::TokenMessengerV2::DepositForBurn;
+//! use alloy_sol_types::SolEvent;
+//!
+//! # fn example(log: &alloy_primitives::Log) -> Result<(), alloy_sol_types::Error> {
+//! let _topic = DepositForBurn::SIGNATURE_HASH;
+//! let _decoded = DepositForBurn::decode_log(log)?;
+//! # Ok(())
+//! # }
+//! ```
 
 mod bridge;
 mod chain;
@@ -145,9 +161,12 @@ pub use chain::addresses::{
 pub use chain::{CctpV1, CctpV2};
 pub use contracts::{
     erc20::Erc20Contract,
-    message_transmitter::MessageTransmitterContract,
-    token_messenger::TokenMessengerContract,
-    v2::{MessageTransmitterV2Contract, TokenMessengerV2Contract},
+    message_transmitter::{MessageTransmitter, MessageTransmitterContract},
+    token_messenger::{TokenMessenger, TokenMessengerContract},
+    v2::{
+        MessageTransmitterV2, MessageTransmitterV2Contract, TokenMessengerV2,
+        TokenMessengerV2Contract,
+    },
 };
 pub use error::{AttestationFailureKind, CctpError, Result};
 pub use protocol::{


### PR DESCRIPTION
## Summary

Ships **v5.1.0** of `cctp-rs`. Minor-version bump for a purely additive public API change.

### Feature (closes #189)

Re-exports the four `sol!`-generated contract modules (`TokenMessenger`, `MessageTransmitter`, `TokenMessengerV2`, `MessageTransmitterV2`) at the crate root alongside the existing `*Contract` wrappers. Downstream consumers can now decode CCTP event logs against the canonical ABI — e.g. `cctp_rs::TokenMessengerV2::DepositForBurn::SIGNATURE_HASH` and `DepositForBurn::decode_log(&log)` — without redeclaring `sol!` fragments locally. Unblocks indexer and on-chain reconciliation use cases.

Also adds a doctest demonstrating the canonical filter-then-decode pattern, with a note that callers need direct deps on `alloy-sol-types` (for `SolEvent`) and `alloy-primitives` (for `Log`).

### Release prep

- `Cargo.toml`: `5.0.0` → `5.1.0`
- `CHANGELOG.md`: new `## [5.1.0] - 2026-05-13` entry under `### Added`
- `AGENTS.md`: new row in the Public API map for the `sol!`-generated modules

### Also bundled

- `build: update cargo dependencies` — transitive-dep patch bumps to `Cargo.lock` (no `Cargo.toml` changes).

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo test --all-features` — 187 unit tests pass
- [x] `cargo test --doc --all-features` — 26 doc tests pass (including the new `DepositForBurn` decode example)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features` clean
- [x] `cargo build --examples --all-features` clean
- [ ] On merge, tag `v5.1.0` on `main` and push — GitHub Actions publishes to crates.io