### PR TITLE
fix: prevent leaking attestation spans onto unrelated async tasks

### DIFF
--- a/examples/complete_bridge_trace.rs
+++ b/examples/complete_bridge_trace.rs
@@ -109,7 +109,7 @@ use alloy_chains::NamedChain;
 use alloy_primitives::{Address, FixedBytes, TxHash};
 use alloy_provider::ProviderBuilder;
 use cctp_rs::{Cctp, CctpError};
-use tracing::{error, info, info_span};
+use tracing::{error, info, info_span, Instrument};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
 
 #[tokio::main]
@@ -204,65 +204,68 @@ async fn demonstrate_complete_bridge_flow(
         destination_chain = %bridge.destination_chain(),
         operation_type = "full_bridge_flow"
     );
-    let _guard = span.enter();
 
-    // Step 1: Get MessageSent event (simulated)
-    info!(step = 1, event = "extracting_message_sent_event");
+    async {
+        // Step 1: Get MessageSent event (simulated)
+        info!(step = 1, event = "extracting_message_sent_event");
 
-    let example_tx_hash: TxHash =
-        "0x9f3ce6edbf3d1f08cfe3a20b7ce43c3d01e55fe3c2d7a9e5a2b5e5c8d6f9c2a1"
-            .parse()
-            .unwrap();
+        let example_tx_hash: TxHash =
+            "0x9f3ce6edbf3d1f08cfe3a20b7ce43c3d01e55fe3c2d7a9e5a2b5e5c8d6f9c2a1"
+                .parse()
+                .unwrap();
 
-    match bridge.get_message_sent_event(example_tx_hash).await {
-        Ok((message, hash)) => {
-            info!(
-                message_length_bytes = message.len(),
-                message_hash = %hash,
-                event = "message_sent_event_extracted_successfully"
-            );
+        match bridge.get_message_sent_event(example_tx_hash).await {
+            Ok((message, hash)) => {
+                info!(
+                    message_length_bytes = message.len(),
+                    message_hash = %hash,
+                    event = "message_sent_event_extracted_successfully"
+                );
+            }
+            Err(e) => {
+                info!(
+                    error = %e,
+                    expected = true,
+                    event = "message_sent_event_not_found_expected"
+                );
+            }
         }
-        Err(e) => {
-            info!(
-                error = %e,
-                expected = true,
-                event = "message_sent_event_not_found_expected"
-            );
+
+        // Step 2: Get attestation with retry
+        info!(step = 2, event = "polling_for_attestation");
+
+        let message_hash: FixedBytes<32> = FixedBytes::from([0xaa; 32]);
+
+        match bridge
+            .get_attestation(
+                message_hash,
+                cctp_rs::PollingConfig::default()
+                    .with_max_attempts(3)
+                    .with_poll_interval_secs(2),
+            )
+            .await
+        {
+            Ok(attestation) => {
+                info!(
+                    attestation_length_bytes = attestation.len(),
+                    event = "attestation_retrieved_successfully"
+                );
+            }
+            Err(e) => {
+                info!(
+                    error_type = "AttestationTimeout",
+                    expected = true,
+                    event = "attestation_timeout_expected"
+                );
+                // Don't log the full error as it's expected
+                let _ = e;
+            }
         }
+
+        info!(event = "bridge_operation_complete");
     }
-
-    // Step 2: Get attestation with retry
-    info!(step = 2, event = "polling_for_attestation");
-
-    let message_hash: FixedBytes<32> = FixedBytes::from([0xaa; 32]);
-
-    match bridge
-        .get_attestation(
-            message_hash,
-            cctp_rs::PollingConfig::default()
-                .with_max_attempts(3)
-                .with_poll_interval_secs(2),
-        )
-        .await
-    {
-        Ok(attestation) => {
-            info!(
-                attestation_length_bytes = attestation.len(),
-                event = "attestation_retrieved_successfully"
-            );
-        }
-        Err(e) => {
-            info!(
-                error_type = "AttestationTimeout",
-                expected = true,
-                event = "attestation_timeout_expected"
-            );
-            // Don't log the full error as it's expected
-            let _ = e;
-        }
-    }
-
-    info!(event = "bridge_operation_complete");
+    .instrument(span)
+    .await;
 }
 
 /// Demonstrates error tracking with OpenTelemetry attributes
@@ -279,51 +282,55 @@ async fn demonstrate_error_tracking(
         "error_tracking_demonstration",
         operation_type = "error_scenarios"
     );
-    let _guard = span.enter();
 
-    // Scenario 1: Transaction not found
-    info!(scenario = 1, event = "testing_transaction_not_found");
+    async {
+        // Scenario 1: Transaction not found
+        info!(scenario = 1, event = "testing_transaction_not_found");
 
-    let invalid_tx: TxHash = "0x0000000000000000000000000000000000000000000000000000000000000000"
-        .parse()
-        .unwrap();
+        let invalid_tx: TxHash =
+            "0x0000000000000000000000000000000000000000000000000000000000000000"
+                .parse()
+                .unwrap();
 
-    match bridge.get_message_sent_event(invalid_tx).await {
-        Ok(_) => {
-            info!(event = "unexpected_success");
+        match bridge.get_message_sent_event(invalid_tx).await {
+            Ok(_) => {
+                info!(event = "unexpected_success");
+            }
+            Err(e) => {
+                // Error is already recorded on span via record_error_with_context
+                info!(error_recorded = true, event = "error_attributes_captured");
+                // Note: error.type, error.message, error.context are now on the span
+                let _ = e;
+            }
         }
-        Err(e) => {
-            // Error is already recorded on span via record_error_with_context
-            info!(error_recorded = true, event = "error_attributes_captured");
-            // Note: error.type, error.message, error.context are now on the span
-            let _ = e;
+
+        // Scenario 2: Invalid message hash for attestation
+        info!(scenario = 2, event = "testing_attestation_not_found");
+
+        let invalid_hash: FixedBytes<32> = FixedBytes::from([0x00; 32]);
+
+        match bridge
+            .get_attestation(
+                invalid_hash,
+                cctp_rs::PollingConfig::default()
+                    .with_max_attempts(2)
+                    .with_poll_interval_secs(1),
+            )
+            .await
+        {
+            Ok(_) => {
+                info!(event = "unexpected_success");
+            }
+            Err(e) => {
+                info!(error_recorded = true, event = "error_attributes_captured");
+                let _ = e;
+            }
         }
+
+        info!(event = "error_tracking_demonstration_complete");
     }
-
-    // Scenario 2: Invalid message hash for attestation
-    info!(scenario = 2, event = "testing_attestation_not_found");
-
-    let invalid_hash: FixedBytes<32> = FixedBytes::from([0x00; 32]);
-
-    match bridge
-        .get_attestation(
-            invalid_hash,
-            cctp_rs::PollingConfig::default()
-                .with_max_attempts(2)
-                .with_poll_interval_secs(1),
-        )
-        .await
-    {
-        Ok(_) => {
-            info!(event = "unexpected_success");
-        }
-        Err(e) => {
-            info!(error_recorded = true, event = "error_attributes_captured");
-            let _ = e;
-        }
-    }
-
-    info!(event = "error_tracking_demonstration_complete");
+    .instrument(span)
+    .await;
 }
 
 /// Demonstrates chain validation error tracking

--- a/src/bridge/cctp.rs
+++ b/src/bridge/cctp.rs
@@ -15,7 +15,7 @@ use bon::Builder;
 use reqwest::{Client, Response};
 use std::time::Duration;
 use tokio::time::sleep;
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, Instrument};
 use url::Url;
 
 use super::bridge_trait::CctpBridge;
@@ -119,75 +119,78 @@ impl<P: Provider<Ethereum> + Clone> Cctp<P> {
     ) -> Result<(Vec<u8>, FixedBytes<32>)> {
         let span =
             spans::get_message_sent_event(tx_hash, &self.source_chain, &self.destination_chain);
-        let _guard = span.enter();
 
-        let tx_receipt = match self.source_provider.get_transaction_receipt(tx_hash).await {
-            Ok(receipt) => receipt,
-            Err(e) => {
-                spans::record_error_with_context(
-                    "ReceiptRetrievalFailed",
-                    &format!("Failed to get transaction receipt: {e}"),
-                    Some("RPC call to get_transaction_receipt failed"),
-                );
-                error!(
-                    error = %e,
-                    event = "transaction_receipt_retrieval_failed"
-                );
-                return Err(e.into());
-            }
-        };
-
-        if let Some(tx_receipt) = tx_receipt {
-            // Calculate the event topic by hashing the event signature
-            let message_sent_topic = alloy_primitives::keccak256(b"MessageSent(bytes)");
-
-            let message_sent_log = tx_receipt
-                .inner
-                .logs()
-                .iter()
-                .find(|log| {
-                    log.topics()
-                        .first()
-                        .is_some_and(|topic| topic.as_slice() == message_sent_topic)
-                })
-                .ok_or_else(|| {
+        async move {
+            let tx_receipt = match self.source_provider.get_transaction_receipt(tx_hash).await {
+                Ok(receipt) => receipt,
+                Err(e) => {
                     spans::record_error_with_context(
-                        "MessageSentEventNotFound",
-                        "MessageSent event not found in transaction logs",
-                        Some(&format!(
-                            "Transaction contained {} logs but none matched MessageSent signature",
-                            tx_receipt.inner.logs().len()
-                        )),
+                        "ReceiptRetrievalFailed",
+                        &format!("Failed to get transaction receipt: {e}"),
+                        Some("RPC call to get_transaction_receipt failed"),
                     );
                     error!(
-                        available_logs = tx_receipt.inner.logs().len(),
-                        event = "message_sent_event_not_found"
+                        error = %e,
+                        event = "transaction_receipt_retrieval_failed"
                     );
-                    CctpError::MessageSentEventMissing { tx_hash }
-                })?;
+                    return Err(e.into());
+                }
+            };
 
-            // Decode the log data using the generated event bindings
-            let decoded = MessageSent::abi_decode_data(&message_sent_log.data().data)?;
+            if let Some(tx_receipt) = tx_receipt {
+                // Calculate the event topic by hashing the event signature
+                let message_sent_topic = alloy_primitives::keccak256(b"MessageSent(bytes)");
 
-            let message_sent_event = decoded.0.to_vec();
-            let message_hash = alloy_primitives::keccak256(&message_sent_event);
+                let message_sent_log = tx_receipt
+                    .inner
+                    .logs()
+                    .iter()
+                    .find(|log| {
+                        log.topics()
+                            .first()
+                            .is_some_and(|topic| topic.as_slice() == message_sent_topic)
+                    })
+                    .ok_or_else(|| {
+                        spans::record_error_with_context(
+                            "MessageSentEventNotFound",
+                            "MessageSent event not found in transaction logs",
+                            Some(&format!(
+                                "Transaction contained {} logs but none matched MessageSent signature",
+                                tx_receipt.inner.logs().len()
+                            )),
+                        );
+                        error!(
+                            available_logs = tx_receipt.inner.logs().len(),
+                            event = "message_sent_event_not_found"
+                        );
+                        CctpError::MessageSentEventMissing { tx_hash }
+                    })?;
 
-            info!(
-                message_hash = %hex::encode(message_hash),
-                message_length_bytes = message_sent_event.len(),
-                event = "message_sent_event_extracted"
-            );
+                // Decode the log data using the generated event bindings
+                let decoded = MessageSent::abi_decode_data(&message_sent_log.data().data)?;
 
-            Ok((message_sent_event, message_hash))
-        } else {
-            spans::record_error_with_context(
-                "TransactionNotFound",
-                "Transaction receipt not found",
-                Some("The transaction may not have been mined yet or the RPC node doesn't have it"),
-            );
-            error!(event = "transaction_not_found");
-            Err(CctpError::TransactionNotFound { tx_hash })
+                let message_sent_event = decoded.0.to_vec();
+                let message_hash = alloy_primitives::keccak256(&message_sent_event);
+
+                info!(
+                    message_hash = %hex::encode(message_hash),
+                    message_length_bytes = message_sent_event.len(),
+                    event = "message_sent_event_extracted"
+                );
+
+                Ok((message_sent_event, message_hash))
+            } else {
+                spans::record_error_with_context(
+                    "TransactionNotFound",
+                    "Transaction receipt not found",
+                    Some("The transaction may not have been mined yet or the RPC node doesn't have it"),
+                );
+                error!(event = "transaction_not_found");
+                Err(CctpError::TransactionNotFound { tx_hash })
+            }
         }
+        .instrument(span)
+        .await
     }
 
     /// Gets the attestation for a message hash from Circle's Iris API
@@ -245,134 +248,152 @@ impl<P: Provider<Ethereum> + Clone> Cctp<P> {
             max_attempts,
             poll_interval,
         );
-        let _guard = span.enter();
 
-        let client = Client::builder()
-            .timeout(Duration::from_secs(30))
-            .build()
-            .map_err(CctpError::Network)?;
-        let url = self.create_url(message_hash)?;
+        async move {
+            let client = Client::builder()
+                .timeout(Duration::from_secs(30))
+                .build()
+                .map_err(CctpError::Network)?;
+            let url = self.create_url(message_hash)?;
 
-        info!(
-            url = %url,
-            event = "attestation_polling_started"
-        );
+            info!(
+                url = %url,
+                event = "attestation_polling_started"
+            );
 
-        for attempt in 1..=max_attempts {
-            let attempt_span = spans::get_attestation(&url, attempt);
-            let _attempt_guard = attempt_span.enter();
-
-            let response = match self.fetch_attestation_response(&client, &url).await {
-                Ok(r) => r,
-                Err(e) => {
-                    spans::record_error_with_context(
-                        "HttpRequestFailed",
-                        &format!("Failed to fetch attestation: {e}"),
-                        Some(&format!("Attempt {attempt}/{max_attempts}")),
-                    );
-                    error!(
-                        error = %e,
-                        attempt = attempt,
-                        event = "attestation_http_request_failed"
-                    );
-                    return Err(e);
-                }
-            };
-
-            let status_code = response.status().as_u16();
-            let process_span = spans::process_attestation_response(status_code, attempt);
-            let _process_guard = process_span.enter();
-
-            // Handle rate limiting
-            if response.status() == reqwest::StatusCode::TOO_MANY_REQUESTS {
-                let secs = 5 * 60;
-                debug!(sleep_secs = secs, event = "rate_limit_exceeded");
-                sleep(Duration::from_secs(secs)).await;
-                continue;
-            }
-
-            // Handle 404 status - treat as pending since the attestation likely doesn't exist yet
-            if response.status() == reqwest::StatusCode::NOT_FOUND {
-                debug!(event = "attestation_not_found");
-                sleep(Duration::from_secs(poll_interval)).await;
-                continue;
-            }
-
-            // Ensure the response status is successful before trying to parse JSON
-            response.error_for_status_ref()?;
-
-            // Get response body as text first for better error logging
-            let response_text = response.text().await?;
-
-            let attestation: AttestationResponse = match serde_json::from_str(&response_text) {
-                Ok(attestation) => attestation,
-                Err(e) => {
-                    error!(
-                        error = %e,
-                        response_body = %response_text,
-                        message_hash = %hex::encode(message_hash),
-                        attempt = attempt,
-                        event = "attestation_decode_failed"
-                    );
-                    sleep(Duration::from_secs(poll_interval)).await;
-                    continue;
-                }
-            };
-
-            match attestation.status {
-                AttestationStatus::Complete => {
-                    let attestation_bytes = attestation
-                        .attestation
-                        .ok_or_else(|| {
+            for attempt in 1..=max_attempts {
+                let attempt_span = spans::get_attestation(&url, attempt);
+                let attempt_result: Result<Option<AttestationBytes>> = async {
+                    let response = match self.fetch_attestation_response(&client, &url).await {
+                        Ok(r) => r,
+                        Err(e) => {
                             spans::record_error_with_context(
-                                "AttestationDataMissing",
-                                "Attestation status is complete but attestation field is null",
-                                Some("This indicates an unexpected API response format"),
+                                "HttpRequestFailed",
+                                &format!("Failed to fetch attestation: {e}"),
+                                Some(&format!("Attempt {attempt}/{max_attempts}")),
                             );
-                            error!(event = "attestation_data_missing");
-                            CctpError::AttestationFailed(AttestationFailureKind::AttestationMissing)
-                        })?
-                        .to_vec();
+                            error!(
+                                error = %e,
+                                attempt = attempt,
+                                event = "attestation_http_request_failed"
+                            );
+                            return Err(e);
+                        }
+                    };
 
-                    info!(
-                        attestation_length_bytes = attestation_bytes.len(),
-                        event = "attestation_complete"
-                    );
-                    return Ok(attestation_bytes);
+                    let status_code = response.status().as_u16();
+                    let process_span = spans::process_attestation_response(status_code, attempt);
+
+                    async {
+                        // Handle rate limiting
+                        if response.status() == reqwest::StatusCode::TOO_MANY_REQUESTS {
+                            let secs = 5 * 60;
+                            debug!(sleep_secs = secs, event = "rate_limit_exceeded");
+                            sleep(Duration::from_secs(secs)).await;
+                            return Ok(None);
+                        }
+
+                        // Handle 404 status - treat as pending since the attestation likely doesn't exist yet
+                        if response.status() == reqwest::StatusCode::NOT_FOUND {
+                            debug!(event = "attestation_not_found");
+                            sleep(Duration::from_secs(poll_interval)).await;
+                            return Ok(None);
+                        }
+
+                        // Ensure the response status is successful before trying to parse JSON
+                        response.error_for_status_ref()?;
+
+                        // Get response body as text first for better error logging
+                        let response_text = response.text().await?;
+
+                        let attestation: AttestationResponse =
+                            match serde_json::from_str(&response_text) {
+                                Ok(attestation) => attestation,
+                                Err(e) => {
+                                    error!(
+                                        error = %e,
+                                        response_body = %response_text,
+                                        message_hash = %hex::encode(message_hash),
+                                        attempt = attempt,
+                                        event = "attestation_decode_failed"
+                                    );
+                                    sleep(Duration::from_secs(poll_interval)).await;
+                                    return Ok(None);
+                                }
+                            };
+
+                        match attestation.status {
+                            AttestationStatus::Complete => {
+                                let attestation_bytes = attestation
+                                    .attestation
+                                    .ok_or_else(|| {
+                                        spans::record_error_with_context(
+                                            "AttestationDataMissing",
+                                            "Attestation status is complete but attestation field is null",
+                                            Some("This indicates an unexpected API response format"),
+                                        );
+                                        error!(event = "attestation_data_missing");
+                                        CctpError::AttestationFailed(
+                                            AttestationFailureKind::AttestationMissing,
+                                        )
+                                    })?
+                                    .to_vec();
+
+                                info!(
+                                    attestation_length_bytes = attestation_bytes.len(),
+                                    event = "attestation_complete"
+                                );
+                                Ok(Some(attestation_bytes))
+                            }
+                            AttestationStatus::Failed => {
+                                spans::record_error_with_context(
+                                    "AttestationFailed",
+                                    "Circle API returned failed status for attestation",
+                                    Some(
+                                        "The message may be invalid or the source transaction may have failed",
+                                    ),
+                                );
+                                error!(event = "attestation_failed");
+                                Err(CctpError::AttestationFailed(
+                                    AttestationFailureKind::ApiReportedFailed,
+                                ))
+                            }
+                            AttestationStatus::Pending | AttestationStatus::PendingConfirmations => {
+                                debug!(event = "attestation_pending");
+                                sleep(Duration::from_secs(poll_interval)).await;
+                                Ok(None)
+                            }
+                        }
+                    }
+                    .instrument(process_span)
+                    .await
                 }
-                AttestationStatus::Failed => {
-                    spans::record_error_with_context(
-                        "AttestationFailed",
-                        "Circle API returned failed status for attestation",
-                        Some(
-                            "The message may be invalid or the source transaction may have failed",
-                        ),
-                    );
-                    error!(event = "attestation_failed");
-                    return Err(CctpError::AttestationFailed(
-                        AttestationFailureKind::ApiReportedFailed,
-                    ));
-                }
-                AttestationStatus::Pending | AttestationStatus::PendingConfirmations => {
-                    debug!(event = "attestation_pending");
-                    sleep(Duration::from_secs(poll_interval)).await;
+                .instrument(attempt_span)
+                .await;
+
+                match attempt_result {
+                    Ok(Some(bytes)) => return Ok(bytes),
+                    Ok(None) => continue,
+                    Err(e) => return Err(e),
                 }
             }
-        }
 
-        spans::record_error_with_context(
-            "AttestationTimeout",
-            &format!("Attestation polling timed out after {max_attempts} attempts"),
-            Some(&format!(
-                "Total duration: {} seconds",
-                u64::from(max_attempts) * poll_interval
-            )),
-        );
-        error!(
-            total_duration_secs = u64::from(max_attempts) * poll_interval,
-            event = "attestation_timeout"
-        );
-        Err(CctpError::AttestationTimeout)
+            spans::record_error_with_context(
+                "AttestationTimeout",
+                &format!("Attestation polling timed out after {max_attempts} attempts"),
+                Some(&format!(
+                    "Total duration: {} seconds",
+                    u64::from(max_attempts) * poll_interval
+                )),
+            );
+            error!(
+                total_duration_secs = u64::from(max_attempts) * poll_interval,
+                event = "attestation_timeout"
+            );
+            Err(CctpError::AttestationTimeout)
+        }
+        .instrument(span)
+        .await
     }
 
     /// Constructs the Iris API URL for attestation polling

--- a/src/bridge/v2.rs
+++ b/src/bridge/v2.rs
@@ -16,7 +16,7 @@ use reqwest::{Client, Response};
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
 use tokio::time::sleep;
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, Instrument};
 use url::Url;
 
 /// Result of attempting to mint on the destination chain
@@ -203,78 +203,81 @@ impl<P: Provider<Ethereum> + Clone> CctpV2<P> {
     ) -> Result<(Vec<u8>, FixedBytes<32>)> {
         let span =
             spans::get_message_sent_event(tx_hash, &self.source_chain, &self.destination_chain);
-        let _guard = span.enter();
 
-        let tx_receipt = match self.source_provider.get_transaction_receipt(tx_hash).await {
-            Ok(receipt) => receipt,
-            Err(e) => {
-                spans::record_error_with_context(
-                    "ReceiptRetrievalFailed",
-                    &format!("Failed to get transaction receipt: {e}"),
-                    Some("RPC call to get_transaction_receipt failed"),
-                );
-                error!(
-                    error = %e,
-                    event = "transaction_receipt_retrieval_failed"
-                );
-                return Err(e.into());
-            }
-        };
-
-        if let Some(tx_receipt) = tx_receipt {
-            // Calculate the event topic by hashing the event signature
-            let message_sent_topic = alloy_primitives::keccak256(b"MessageSent(bytes)");
-
-            let message_sent_log = tx_receipt
-                .inner
-                .logs()
-                .iter()
-                .find(|log| {
-                    log.topics()
-                        .first()
-                        .is_some_and(|topic| topic.as_slice() == message_sent_topic)
-                })
-                .ok_or_else(|| {
+        async move {
+            let tx_receipt = match self.source_provider.get_transaction_receipt(tx_hash).await {
+                Ok(receipt) => receipt,
+                Err(e) => {
                     spans::record_error_with_context(
-                        "MessageSentEventNotFound",
-                        "MessageSent event not found in transaction logs",
-                        Some(&format!(
-                            "Transaction contained {} logs but none matched MessageSent signature",
-                            tx_receipt.inner.logs().len()
-                        )),
+                        "ReceiptRetrievalFailed",
+                        &format!("Failed to get transaction receipt: {e}"),
+                        Some("RPC call to get_transaction_receipt failed"),
                     );
                     error!(
-                        available_logs = tx_receipt.inner.logs().len(),
-                        event = "message_sent_event_not_found"
+                        error = %e,
+                        event = "transaction_receipt_retrieval_failed"
                     );
-                    CctpError::MessageSentEventMissing { tx_hash }
-                })?;
+                    return Err(e.into());
+                }
+            };
 
-            // Decode the log data using the generated event bindings
-            let decoded = MessageSent::abi_decode_data(&message_sent_log.data().data)?;
+            if let Some(tx_receipt) = tx_receipt {
+                // Calculate the event topic by hashing the event signature
+                let message_sent_topic = alloy_primitives::keccak256(b"MessageSent(bytes)");
 
-            let message_sent_event = decoded.0.to_vec();
-            let message_hash = alloy_primitives::keccak256(&message_sent_event);
+                let message_sent_log = tx_receipt
+                    .inner
+                    .logs()
+                    .iter()
+                    .find(|log| {
+                        log.topics()
+                            .first()
+                            .is_some_and(|topic| topic.as_slice() == message_sent_topic)
+                    })
+                    .ok_or_else(|| {
+                        spans::record_error_with_context(
+                            "MessageSentEventNotFound",
+                            "MessageSent event not found in transaction logs",
+                            Some(&format!(
+                                "Transaction contained {} logs but none matched MessageSent signature",
+                                tx_receipt.inner.logs().len()
+                            )),
+                        );
+                        error!(
+                            available_logs = tx_receipt.inner.logs().len(),
+                            event = "message_sent_event_not_found"
+                        );
+                        CctpError::MessageSentEventMissing { tx_hash }
+                    })?;
 
-            info!(
-                message_hash = %hex::encode(message_hash),
-                message_length_bytes = message_sent_event.len(),
-                version = "v2",
-                fast_transfer = self.fast_transfer,
-                has_hooks = self.hook_data.is_some(),
-                event = "message_sent_event_extracted"
-            );
+                // Decode the log data using the generated event bindings
+                let decoded = MessageSent::abi_decode_data(&message_sent_log.data().data)?;
 
-            Ok((message_sent_event, message_hash))
-        } else {
-            spans::record_error_with_context(
-                "TransactionNotFound",
-                "Transaction receipt not found",
-                Some("The transaction may not have been mined yet or the RPC node doesn't have it"),
-            );
-            error!(event = "transaction_not_found");
-            Err(CctpError::TransactionNotFound { tx_hash })
+                let message_sent_event = decoded.0.to_vec();
+                let message_hash = alloy_primitives::keccak256(&message_sent_event);
+
+                info!(
+                    message_hash = %hex::encode(message_hash),
+                    message_length_bytes = message_sent_event.len(),
+                    version = "v2",
+                    fast_transfer = self.fast_transfer,
+                    has_hooks = self.hook_data.is_some(),
+                    event = "message_sent_event_extracted"
+                );
+
+                Ok((message_sent_event, message_hash))
+            } else {
+                spans::record_error_with_context(
+                    "TransactionNotFound",
+                    "Transaction receipt not found",
+                    Some("The transaction may not have been mined yet or the RPC node doesn't have it"),
+                );
+                error!(event = "transaction_not_found");
+                Err(CctpError::TransactionNotFound { tx_hash })
+            }
         }
+        .instrument(span)
+        .await
     }
 
     /// Gets the attestation and canonical message for a transaction from Circle's Iris API (v2)
@@ -344,167 +347,187 @@ impl<P: Provider<Ethereum> + Clone> CctpV2<P> {
             max_attempts,
             poll_interval,
         );
-        let _guard = span.enter();
 
-        let client = Client::builder()
-            .timeout(Duration::from_secs(30))
-            .build()
-            .map_err(CctpError::Network)?;
-        let url = self.create_url(tx_hash)?;
+        async move {
+            let client = Client::builder()
+                .timeout(Duration::from_secs(30))
+                .build()
+                .map_err(CctpError::Network)?;
+            let url = self.create_url(tx_hash)?;
 
-        info!(
-            url = %url,
-            tx_hash = %tx_hash,
-            version = "v2",
-            fast_transfer = self.fast_transfer,
-            finality_threshold = %self.finality_threshold(),
-            event = "attestation_polling_started"
-        );
+            info!(
+                url = %url,
+                tx_hash = %tx_hash,
+                version = "v2",
+                fast_transfer = self.fast_transfer,
+                finality_threshold = %self.finality_threshold(),
+                event = "attestation_polling_started"
+            );
 
-        for attempt in 1..=max_attempts {
-            let attempt_span = spans::get_attestation(&url, attempt);
-            let _attempt_guard = attempt_span.enter();
-
-            let response = match self.fetch_attestation_response(&client, &url).await {
-                Ok(r) => r,
-                Err(e) => {
-                    spans::record_error_with_context(
-                        "HttpRequestFailed",
-                        &format!("Failed to fetch attestation: {e}"),
-                        Some(&format!("Attempt {attempt}/{max_attempts}")),
-                    );
-                    error!(
-                        error = %e,
-                        attempt = attempt,
-                        event = "attestation_http_request_failed"
-                    );
-                    return Err(e);
-                }
-            };
-
-            let status_code = response.status().as_u16();
-            let process_span = spans::process_attestation_response(status_code, attempt);
-            let _process_guard = process_span.enter();
-
-            // Handle rate limiting
-            if response.status() == reqwest::StatusCode::TOO_MANY_REQUESTS {
-                let secs = 5 * 60;
-                debug!(sleep_secs = secs, event = "rate_limit_exceeded");
-                sleep(Duration::from_secs(secs)).await;
-                continue;
-            }
-
-            // Handle 404 status - treat as pending since the attestation likely doesn't exist yet
-            if response.status() == reqwest::StatusCode::NOT_FOUND {
-                debug!(event = "attestation_not_found");
-                sleep(Duration::from_secs(poll_interval)).await;
-                continue;
-            }
-
-            // Ensure the response status is successful before trying to parse JSON
-            response.error_for_status_ref()?;
-
-            // Get response body as text first for better error logging
-            let response_text = response.text().await?;
-
-            // Parse v2 response format (array of messages)
-            let v2_response: V2AttestationResponse = match serde_json::from_str(&response_text) {
-                Ok(response) => response,
-                Err(e) => {
-                    error!(
-                        error = %e,
-                        response_body = %response_text,
-                        tx_hash = %tx_hash,
-                        attempt = attempt,
-                        event = "attestation_decode_failed"
-                    );
-                    sleep(Duration::from_secs(poll_interval)).await;
-                    continue;
-                }
-            };
-
-            // V2 returns an array of messages - get the first one
-            let message = match v2_response.messages.first() {
-                Some(msg) => msg,
-                None => {
-                    debug!(event = "no_messages_in_response");
-                    sleep(Duration::from_secs(poll_interval)).await;
-                    continue;
-                }
-            };
-
-            match message.status {
-                AttestationStatus::Complete => {
-                    let attestation_bytes = message
-                        .attestation
-                        .as_ref()
-                        .ok_or_else(|| {
+            for attempt in 1..=max_attempts {
+                let attempt_span = spans::get_attestation(&url, attempt);
+                let attempt_result: Result<Option<(Vec<u8>, AttestationBytes)>> = async {
+                    let response = match self.fetch_attestation_response(&client, &url).await {
+                        Ok(r) => r,
+                        Err(e) => {
                             spans::record_error_with_context(
-                                "AttestationDataMissing",
-                                "Attestation status is complete but attestation field is null",
-                                Some("This indicates an unexpected API response format"),
+                                "HttpRequestFailed",
+                                &format!("Failed to fetch attestation: {e}"),
+                                Some(&format!("Attempt {attempt}/{max_attempts}")),
                             );
-                            error!(event = "attestation_data_missing");
-                            CctpError::AttestationFailed(AttestationFailureKind::AttestationMissing)
-                        })?
-                        .to_vec();
-
-                    let message_bytes = message
-                        .message
-                        .as_ref()
-                        .ok_or_else(|| {
-                            spans::record_error_with_context(
-                                "MessageDataMissing",
-                                "Attestation status is complete but message field is null",
-                                Some("This indicates an unexpected API response format"),
+                            error!(
+                                error = %e,
+                                attempt = attempt,
+                                event = "attestation_http_request_failed"
                             );
-                            error!(event = "message_data_missing");
-                            CctpError::AttestationFailed(AttestationFailureKind::MessageMissing)
-                        })?
-                        .to_vec();
+                            return Err(e);
+                        }
+                    };
 
-                    info!(
-                        message_length_bytes = message_bytes.len(),
-                        attestation_length_bytes = attestation_bytes.len(),
-                        version = "v2",
-                        fast_transfer = self.fast_transfer,
-                        event = "attestation_complete"
-                    );
-                    return Ok((message_bytes, attestation_bytes));
+                    let status_code = response.status().as_u16();
+                    let process_span = spans::process_attestation_response(status_code, attempt);
+
+                    async {
+                        // Handle rate limiting
+                        if response.status() == reqwest::StatusCode::TOO_MANY_REQUESTS {
+                            let secs = 5 * 60;
+                            debug!(sleep_secs = secs, event = "rate_limit_exceeded");
+                            sleep(Duration::from_secs(secs)).await;
+                            return Ok(None);
+                        }
+
+                        // Handle 404 status - treat as pending since the attestation likely doesn't exist yet
+                        if response.status() == reqwest::StatusCode::NOT_FOUND {
+                            debug!(event = "attestation_not_found");
+                            sleep(Duration::from_secs(poll_interval)).await;
+                            return Ok(None);
+                        }
+
+                        // Ensure the response status is successful before trying to parse JSON
+                        response.error_for_status_ref()?;
+
+                        // Get response body as text first for better error logging
+                        let response_text = response.text().await?;
+
+                        // Parse v2 response format (array of messages)
+                        let v2_response: V2AttestationResponse =
+                            match serde_json::from_str(&response_text) {
+                                Ok(response) => response,
+                                Err(e) => {
+                                    error!(
+                                        error = %e,
+                                        response_body = %response_text,
+                                        tx_hash = %tx_hash,
+                                        attempt = attempt,
+                                        event = "attestation_decode_failed"
+                                    );
+                                    sleep(Duration::from_secs(poll_interval)).await;
+                                    return Ok(None);
+                                }
+                            };
+
+                        // V2 returns an array of messages - get the first one
+                        let message = match v2_response.messages.first() {
+                            Some(msg) => msg,
+                            None => {
+                                debug!(event = "no_messages_in_response");
+                                sleep(Duration::from_secs(poll_interval)).await;
+                                return Ok(None);
+                            }
+                        };
+
+                        match message.status {
+                            AttestationStatus::Complete => {
+                                let attestation_bytes = message
+                                    .attestation
+                                    .as_ref()
+                                    .ok_or_else(|| {
+                                        spans::record_error_with_context(
+                                            "AttestationDataMissing",
+                                            "Attestation status is complete but attestation field is null",
+                                            Some("This indicates an unexpected API response format"),
+                                        );
+                                        error!(event = "attestation_data_missing");
+                                        CctpError::AttestationFailed(
+                                            AttestationFailureKind::AttestationMissing,
+                                        )
+                                    })?
+                                    .to_vec();
+
+                                let message_bytes = message
+                                    .message
+                                    .as_ref()
+                                    .ok_or_else(|| {
+                                        spans::record_error_with_context(
+                                            "MessageDataMissing",
+                                            "Attestation status is complete but message field is null",
+                                            Some("This indicates an unexpected API response format"),
+                                        );
+                                        error!(event = "message_data_missing");
+                                        CctpError::AttestationFailed(
+                                            AttestationFailureKind::MessageMissing,
+                                        )
+                                    })?
+                                    .to_vec();
+
+                                info!(
+                                    message_length_bytes = message_bytes.len(),
+                                    attestation_length_bytes = attestation_bytes.len(),
+                                    version = "v2",
+                                    fast_transfer = self.fast_transfer,
+                                    event = "attestation_complete"
+                                );
+                                Ok(Some((message_bytes, attestation_bytes)))
+                            }
+                            AttestationStatus::Failed => {
+                                spans::record_error_with_context(
+                                    "AttestationFailed",
+                                    "Circle API returned failed status for attestation",
+                                    Some(
+                                        "The message may be invalid or the source transaction may have failed",
+                                    ),
+                                );
+                                error!(event = "attestation_failed");
+                                Err(CctpError::AttestationFailed(
+                                    AttestationFailureKind::ApiReportedFailed,
+                                ))
+                            }
+                            AttestationStatus::Pending | AttestationStatus::PendingConfirmations => {
+                                debug!(event = "attestation_pending");
+                                sleep(Duration::from_secs(poll_interval)).await;
+                                Ok(None)
+                            }
+                        }
+                    }
+                    .instrument(process_span)
+                    .await
                 }
-                AttestationStatus::Failed => {
-                    spans::record_error_with_context(
-                        "AttestationFailed",
-                        "Circle API returned failed status for attestation",
-                        Some(
-                            "The message may be invalid or the source transaction may have failed",
-                        ),
-                    );
-                    error!(event = "attestation_failed");
-                    return Err(CctpError::AttestationFailed(
-                        AttestationFailureKind::ApiReportedFailed,
-                    ));
-                }
-                AttestationStatus::Pending | AttestationStatus::PendingConfirmations => {
-                    debug!(event = "attestation_pending");
-                    sleep(Duration::from_secs(poll_interval)).await;
+                .instrument(attempt_span)
+                .await;
+
+                match attempt_result {
+                    Ok(Some(pair)) => return Ok(pair),
+                    Ok(None) => continue,
+                    Err(e) => return Err(e),
                 }
             }
+
+            spans::record_error_with_context(
+                "AttestationTimeout",
+                &format!("Attestation polling timed out after {max_attempts} attempts"),
+                Some(&format!(
+                    "Total duration: {} seconds",
+                    u64::from(max_attempts) * poll_interval
+                )),
+            );
+            error!(
+                total_duration_secs = u64::from(max_attempts) * poll_interval,
+                event = "attestation_timeout"
+            );
+            Err(CctpError::AttestationTimeout)
         }
-
-        spans::record_error_with_context(
-            "AttestationTimeout",
-            &format!("Attestation polling timed out after {max_attempts} attempts"),
-            Some(&format!(
-                "Total duration: {} seconds",
-                u64::from(max_attempts) * poll_interval
-            )),
-        );
-        error!(
-            total_duration_secs = u64::from(max_attempts) * poll_interval,
-            event = "attestation_timeout"
-        );
-        Err(CctpError::AttestationTimeout)
+        .instrument(span)
+        .await
     }
 
     /// Initiate a USDC burn on the source chain

--- a/src/spans.rs
+++ b/src/spans.rs
@@ -15,12 +15,19 @@
 //!
 //! # Example
 //!
+//! These helpers return [`tracing::Span`]s ready to attach to either
+//! synchronous scopes via [`Span::in_scope`] or asynchronous work via
+//! [`tracing::Instrument`]. **Never hold a `Span::enter()` guard across an
+//! `.await` point** — in async Rust that leaks the entered span onto
+//! unrelated tasks after a scheduler switch and produces misleading traces.
+//!
 //! ```rust,no_run
 //! use cctp_rs::spans;
 //! use alloy_primitives::FixedBytes;
 //! use alloy_chains::NamedChain;
+//! use tracing::Instrument;
 //!
-//! // Create a span for attestation polling
+//! # async fn example() {
 //! let message_hash = FixedBytes::from([0u8; 32]);
 //! let span = spans::get_attestation_with_retry(
 //!     &message_hash,
@@ -29,8 +36,14 @@
 //!     30,  // max attempts
 //!     60,  // poll interval
 //! );
-//! let _guard = span.enter();
-//! // Your custom attestation logic here
+//!
+//! async {
+//!     // Your custom async attestation logic here — every `.await` is
+//!     // properly bracketed by the span via `Instrument`.
+//! }
+//! .instrument(span)
+//! .await;
+//! # }
 //! ```
 
 use alloy_chains::NamedChain;
@@ -259,6 +272,10 @@ pub fn get_transaction_receipt(tx_hash: TxHash, chain: &NamedChain) -> Span {
 ///
 /// # Example
 ///
+/// Call from inside a synchronous scope, or from inside an
+/// [`tracing::Instrument`]-attached future — never with a `Span::enter()`
+/// guard held across an `.await`.
+///
 /// ```rust,no_run
 /// use cctp_rs::spans;
 /// use cctp_rs::CctpError;
@@ -291,6 +308,10 @@ pub fn record_error<E: std::error::Error>(error: &E) {
 /// This variant allows adding additional context fields to the error.
 ///
 /// # Example
+///
+/// Call from inside a synchronous scope, or from inside an
+/// [`tracing::Instrument`]-attached future — never with a `Span::enter()`
+/// guard held across an `.await`.
 ///
 /// ```rust,no_run
 /// use cctp_rs::spans;


### PR DESCRIPTION
## Summary

Async bridge methods previously created a `tracing` span and held a
`Span::enter()` guard live across `.await` points. In async Rust that
makes the entered span "current" on the executor thread even after the
future yields — so events emitted by unrelated tasks scheduled onto the
same thread were recorded under attestation / message-extraction spans,
making production traces misleading. The fix hooks each affected
function's body through `Future::instrument`, which enters the span on
poll and exits it on yield. `Closes #200.`

## What's in the diff

- `src/bridge/cctp.rs` — `get_message_sent_event` and `get_attestation`
  now wrap their async body in `.instrument(span).await`. The retry
  loop's per-attempt body is itself an inner `async { ... }`
  instrumented with the attempt span, with the response-processing
  block instrumented with `process_span`. The loop body now returns
  `Result<Option<AttestationBytes>>` per attempt — `Ok(Some(_))` =
  done, `Ok(None)` = retry, `Err` = fatal — so `continue` / `return`
  no longer crosses the async boundary.
- `src/bridge/v2.rs` — same shape applied to `get_message_sent_event`
  and `get_attestation` for the v2 bridge.
- `examples/complete_bridge_trace.rs` — `demonstrate_complete_bridge_flow`
  and `demonstrate_error_tracking` use `.instrument(span).await`.
  `demonstrate_chain_validation_error` is synchronous and keeps the
  existing `let _guard = span.enter()` — no awaits, no risk.
- `src/spans.rs` — rewrites the module-level example to use
  `.instrument()` (the old example showed the very `Span::enter()`
  pattern being fixed, in a context — `get_attestation_with_retry` —
  that's inherently async). Annotates the sync `record_error` /
  `record_error_with_context` doctests to flag that the entered-guard
  pattern shown there is sync-only.

The three inner spans' parent-child relationships are preserved: outer
retry span → per-attempt span → per-response span, all nested via
`.instrument()` instead of stacked `enter()` guards.

## Acceptance check (from #200)

- [x] No `Span::enter()` guard remains live across an `.await` point in
  the changed files (verified with `grep -n "enter()"` against the
  three files post-change).
- [x] Bridge attestation and event spans still expose useful fields and
  preserve intended parent-child relationships — the span helpers in
  `src/spans.rs` are unchanged, and the creation site of each inner
  span runs while its expected parent is the current span.
- [x] Existing tests and clippy pass.

## Test plan

- [x] `cargo nextest run --workspace --all-features` — 187/187 pass
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo test --doc --all-features` — 26 doctests pass (covers the
  rewritten `src/spans.rs` examples)
- [ ] **No test currently exercises the changed async polling paths.**
  The existing test suite covers only synchronous helpers (URL
  construction, chain-ID resolution). The fix is verified by inspection
  and by the `tracing::Instrument` semantics. Filed as #203 for
  follow-up — adding a `wiremock`-driven test that asserts the
  across-await invariant.

## Follow-ups surfaced during review

- **#201** — `spans::get_attestation` and `spans::process_attestation_response`
  are `debug_span!`s that don't declare `error.*` / `otel.status_code`
  fields, so several `record_error_with_context(...)` calls inside the
  retry loop currently land as silent no-ops. This was true under the
  old guard-based code too — same `Span::current()` chain — so it isn't
  a regression introduced here.
- **#203** — Add `wiremock`-driven tracing-correctness tests for the
  attestation polling loops; without them, a future regression that
  re-introduces the across-await guard would ship silently.