### PR TITLE
test: lock attestation-loop span across-await invariant with wiremock probe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -883,6 +883,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1196,6 +1206,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
+ "wiremock",
 ]
 
 [[package]]
@@ -1452,6 +1463,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1669,7 +1698,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2073,6 +2102,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hybrid-array"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2095,6 +2130,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -2610,7 +2646,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3334,7 +3370,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3391,7 +3427,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3766,7 +3802,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3915,7 +3951,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4490,7 +4526,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4726,6 +4762,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "wiremock"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
+dependencies = [
+ "assert-json-diff",
+ "base64",
+ "deadpool",
+ "futures",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,3 +49,4 @@ tokio = { version = "1.52", features = [
     "rt-multi-thread",
 ] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+wiremock = "0.6"

--- a/src/bridge/cctp.rs
+++ b/src/bridge/cctp.rs
@@ -52,11 +52,20 @@ pub struct Cctp<P: Provider<Ethereum> + Clone> {
     source_chain: NamedChain,
     destination_chain: NamedChain,
     recipient: Address,
+
+    /// Override the Iris API base URL. Primarily intended for pointing the
+    /// bridge at a local mock server (e.g. `wiremock`) in tests, or at a
+    /// custom Iris-compatible endpoint. When `None`, the URL is selected
+    /// from the source chain's mainnet/testnet status.
+    api_url_override: Option<Url>,
 }
 
 impl<P: Provider<Ethereum> + Clone> Cctp<P> {
     /// Returns the CCTP API URL for the current environment
     pub fn api_url(&self) -> Url {
+        if let Some(url) = &self.api_url_override {
+            return url.clone();
+        }
         if self.source_chain.is_testnet() {
             Url::parse(IRIS_API_SANDBOX).unwrap()
         } else {

--- a/src/bridge/v2.rs
+++ b/src/bridge/v2.rs
@@ -101,11 +101,20 @@ pub struct CctpV2<P: Provider<Ethereum> + Clone> {
 
     /// Maximum fee willing to pay for fast transfer (in USDC atomic units)
     max_fee: Option<U256>,
+
+    /// Override the Iris API base URL. Primarily intended for pointing the
+    /// bridge at a local mock server (e.g. `wiremock`) in tests, or at a
+    /// custom Iris-compatible endpoint. When `None`, the URL is selected
+    /// from the source chain's mainnet/testnet status.
+    api_url_override: Option<Url>,
 }
 
 impl<P: Provider<Ethereum> + Clone> CctpV2<P> {
     /// Returns the CCTP v2 API URL for the current environment
     pub fn api_url(&self) -> Url {
+        if let Some(url) = &self.api_url_override {
+            return url.clone();
+        }
         if self.source_chain.is_testnet() {
             Url::parse(IRIS_API_SANDBOX).unwrap()
         } else {

--- a/tests/attestation_polling_tracing.rs
+++ b/tests/attestation_polling_tracing.rs
@@ -1,0 +1,218 @@
+// SPDX-FileCopyrightText: 2025 Semiotic AI, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Tracing-correctness regression tests for the v1 and v2 attestation
+//! polling loops.
+//!
+//! The polling loops must hold their spans across `.await` via
+//! `Future::instrument`, never via a `Span::enter()` guard parked in
+//! the future's state across a suspension point. Holding a guard
+//! across `.await` leaks the entered span onto unrelated tasks once
+//! the executor schedules another future on the same thread, producing
+//! misleading production traces (see #200 / #202).
+//!
+//! Each test drives `get_attestation` against a `wiremock` server that
+//! returns Pending then Complete, and emits a probe `tracing` event
+//! from a sibling `tokio::spawn`-ed task scheduled to fire during the
+//! bridge's inter-attempt sleep. With `Future::instrument`, the
+//! polling spans are exited when the future yields, so the probe sees
+//! none of them as ancestors. With a leaked `Span::enter()` guard, the
+//! probe event would be parented to the polling span and these tests
+//! fail.
+
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use alloy_chains::NamedChain;
+use alloy_network::Ethereum;
+use alloy_primitives::{Address, FixedBytes};
+use alloy_provider::{Provider, ProviderBuilder};
+use cctp_rs::{Cctp, CctpV2Bridge, PollingConfig};
+use tracing::Event;
+use tracing_subscriber::layer::{Context, SubscriberExt};
+use tracing_subscriber::registry::LookupSpan;
+use tracing_subscriber::{Layer, Registry};
+use url::Url;
+use wiremock::matchers::method;
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+const PROBE_TARGET: &str = "cctp_rs_tracing_probe";
+
+#[derive(Default, Debug)]
+struct CapturedProbe {
+    ancestor_span_names: Vec<String>,
+}
+
+struct ProbeCaptureLayer {
+    captures: Arc<Mutex<Vec<CapturedProbe>>>,
+}
+
+impl<S> Layer<S> for ProbeCaptureLayer
+where
+    S: tracing::Subscriber + for<'a> LookupSpan<'a>,
+{
+    fn on_event(&self, event: &Event<'_>, ctx: Context<'_, S>) {
+        if event.metadata().target() != PROBE_TARGET {
+            return;
+        }
+        let mut ancestor_span_names = Vec::new();
+        if let Some(scope) = ctx.event_scope(event) {
+            for span in scope {
+                ancestor_span_names.push(span.name().to_string());
+            }
+        }
+        self.captures.lock().unwrap().push(CapturedProbe {
+            ancestor_span_names,
+        });
+    }
+}
+
+fn install_probe_subscriber() -> (
+    Arc<Mutex<Vec<CapturedProbe>>>,
+    tracing::subscriber::DefaultGuard,
+) {
+    let captures = Arc::new(Mutex::new(Vec::new()));
+    let layer = ProbeCaptureLayer {
+        captures: captures.clone(),
+    };
+    let subscriber = Registry::default().with(layer);
+    let guard = tracing::subscriber::set_default(subscriber);
+    (captures, guard)
+}
+
+fn dummy_provider() -> impl Provider<Ethereum> + Clone {
+    ProviderBuilder::new().connect_http("http://127.0.0.1:1/".parse().unwrap())
+}
+
+fn assert_no_leaked_attestation_span(captures: &[CapturedProbe]) {
+    assert!(
+        !captures.is_empty(),
+        "expected at least one probe event to be captured during polling"
+    );
+    for capture in captures {
+        for ancestor in &capture.ancestor_span_names {
+            assert!(
+                !ancestor.starts_with("cctp_rs."),
+                "probe event was parented to span `{ancestor}`; the \
+                 attestation polling loop is holding a tracing span \
+                 across `.await`. This regresses #200 / #202."
+            );
+        }
+    }
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn v1_attestation_polling_does_not_leak_span_across_await() {
+    let (captures, _guard) = install_probe_subscriber();
+
+    let server = MockServer::start().await;
+    let attestation_hex = format!("0x{}", "ab".repeat(65));
+    Mock::given(method("GET"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "status": "pending_confirmations"
+        })))
+        .up_to_n_times(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "status": "complete",
+            "attestation": attestation_hex,
+        })))
+        .mount(&server)
+        .await;
+
+    let api_override = Url::parse(&server.uri()).expect("wiremock URI parses as Url");
+    let provider = dummy_provider();
+    let bridge = Cctp::builder()
+        .source_chain(NamedChain::Mainnet)
+        .destination_chain(NamedChain::Arbitrum)
+        .source_provider(provider.clone())
+        .destination_provider(provider)
+        .recipient(Address::ZERO)
+        .api_url_override(api_override)
+        .build();
+
+    let probe = tokio::spawn(async {
+        tokio::time::sleep(Duration::from_millis(400)).await;
+        tracing::info!(target: PROBE_TARGET, "probe_during_polling_sleep");
+    });
+
+    let result = bridge
+        .get_attestation(
+            FixedBytes::from([0x12u8; 32]),
+            PollingConfig::default()
+                .with_max_attempts(3)
+                .with_poll_interval_secs(1),
+        )
+        .await;
+    probe.await.expect("probe task panicked");
+
+    let attestation = result.expect("polling should succeed once Complete is returned");
+    assert_eq!(attestation.len(), 65);
+
+    assert_no_leaked_attestation_span(&captures.lock().unwrap());
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn v2_attestation_polling_does_not_leak_span_across_await() {
+    let (captures, _guard) = install_probe_subscriber();
+
+    let server = MockServer::start().await;
+    let message_hex = format!("0x{}", "cc".repeat(228));
+    let attestation_hex = format!("0x{}", "ab".repeat(65));
+    Mock::given(method("GET"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "messages": [
+                { "status": "pending_confirmations" }
+            ]
+        })))
+        .up_to_n_times(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "messages": [
+                {
+                    "status": "complete",
+                    "message": message_hex,
+                    "attestation": attestation_hex,
+                }
+            ]
+        })))
+        .mount(&server)
+        .await;
+
+    let api_override = Url::parse(&server.uri()).expect("wiremock URI parses as Url");
+    let provider = dummy_provider();
+    let bridge = CctpV2Bridge::builder()
+        .source_chain(NamedChain::Mainnet)
+        .destination_chain(NamedChain::Linea)
+        .source_provider(provider.clone())
+        .destination_provider(provider)
+        .recipient(Address::ZERO)
+        .api_url_override(api_override)
+        .build();
+
+    let probe = tokio::spawn(async {
+        tokio::time::sleep(Duration::from_millis(400)).await;
+        tracing::info!(target: PROBE_TARGET, "probe_during_polling_sleep");
+    });
+
+    let result = bridge
+        .get_attestation(
+            FixedBytes::from([0xabu8; 32]),
+            PollingConfig::fast_transfer()
+                .with_max_attempts(3)
+                .with_poll_interval_secs(1),
+        )
+        .await;
+    probe.await.expect("probe task panicked");
+
+    let (message, attestation) = result.expect("polling should succeed once Complete is returned");
+    assert_eq!(message.len(), 228);
+    assert_eq!(attestation.len(), 65);
+
+    assert_no_leaked_attestation_span(&captures.lock().unwrap());
+}


### PR DESCRIPTION
## Summary

Adds an integration test that locks the across-`.await` tracing invariant
on `Cctp::get_attestation` and `CctpV2Bridge::get_attestation` — the
contract restored in #202 (fix for #200). A future refactor swapping
`Future::instrument` for `Span::enter()` held across `.await` would
silently re-leak the attestation span onto unrelated tasks; this test
fails before that regression ships. `Closes #203.`

## What's in the diff

- `tests/attestation_polling_tracing.rs` — new integration test. Drives
  each polling loop against a `wiremock` server that returns Pending
  then Complete, fires a probe `tracing` event from a sibling
  `tokio::spawn` task during the inter-attempt sleep, and asserts via a
  custom `tracing-subscriber` `Layer` that the probe event has no
  ancestor span starting with `cctp_rs.` (i.e. the polling spans were
  properly exited on yield). A reviewer who's skeptical the assertion
  is load-bearing can verify locally by replacing the outer
  `.instrument(span).await` with `let _g = span.clone().enter()` — both
  tests fail with a clear message naming the leaked span.
- `Cargo.toml` — `wiremock = "0.6"` under `[dev-dependencies]`.
- `src/bridge/cctp.rs`, `src/bridge/v2.rs` — add `api_url_override:
  Option<Url>` builder field on `Cctp` / `CctpV2`. `api_url()` honors
  the override when set; otherwise mainnet/testnet selection is
  unchanged. Primarily a test seam, but also useful for users running
  against a custom Iris-compatible endpoint.

## Acceptance check (from #203)

- [x] Polling loop is exercised end-to-end (Pending → Complete) against
  a local HTTP mock, with `tokio::time::sleep` taking the real wall
  clock between attempts.
- [x] The across-await span invariant from #200/#202 is asserted
  directly via a sibling-task probe. A regression in the inner async
  structure surfaces as a probe event parented to `cctp_rs.*`, not as
  silent trace pollution.
- [x] No `wiremock`/`mockito` dependency before; `wiremock` added under
  `[dev-dependencies]` only.

## Test plan

- [x] `cargo test --all-features` — 187 unit + 2 new integration + 26
      doctests pass.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- [x] `cargo fmt --all -- --check` — clean.
- [x] Verified the test fails under the buggy `Span::enter()` pattern
      (panic: "probe event was parented to span
      `cctp_rs.get_attestation_with_retry`").