### PR TITLE
fix: surface per-attempt attestation errors in trace queries

### DIFF
--- a/src/spans.rs
+++ b/src/spans.rs
@@ -138,6 +138,10 @@ pub fn get_attestation(url: &Url, attempt: u32) -> Span {
         "cctp_rs.get_attestation",
         url = %url,
         attempt = attempt,
+        error.type = tracing::field::Empty,
+        error.message = tracing::field::Empty,
+        error.context = tracing::field::Empty,
+        otel.status_code = "OK",
     )
 }
 
@@ -150,6 +154,10 @@ pub fn process_attestation_response(status_code: u16, attempt: u32) -> Span {
         "cctp_rs.process_attestation_response",
         status_code = status_code,
         attempt = attempt,
+        error.type = tracing::field::Empty,
+        error.message = tracing::field::Empty,
+        error.context = tracing::field::Empty,
+        otel.status_code = "OK",
     )
 }
 

--- a/tests/inner_span_error_attributes.rs
+++ b/tests/inner_span_error_attributes.rs
@@ -1,0 +1,308 @@
+// SPDX-FileCopyrightText: 2026 Semiotic AI, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Regression tests for #201: the per-attempt and per-response spans
+//! emitted by the v1 and v2 attestation polling loops must declare
+//! `error.type`, `error.message`, `error.context`, and
+//! `otel.status_code` so that `spans::record_error_with_context` writes
+//! land on the innermost span.
+//!
+//! `tracing::Span::record` silently drops writes for fields that were
+//! not declared at span construction. If the inner spans omit these
+//! field declarations, the error attributes the SDK appears to emit
+//! for `HttpRequestFailed`, `AttestationFailed`,
+//! `AttestationDataMissing`, and `MessageDataMissing` never actually
+//! materialize on any span, breaking Tempo/Jaeger queries like
+//! `{ span.error.type = "HttpRequestFailed" }`.
+//!
+//! Each test installs a `tracing_subscriber::Layer` that captures
+//! `on_record` calls, drives `get_attestation` against a failure
+//! scenario (an unreachable HTTP host for the attempt-span path; a
+//! `failed` Circle API status for the process-response-span path),
+//! and asserts that the expected field landed on the expected span.
+
+use std::sync::{Arc, Mutex};
+
+use alloy_chains::NamedChain;
+use alloy_network::Ethereum;
+use alloy_primitives::{Address, FixedBytes};
+use alloy_provider::{Provider, ProviderBuilder};
+use cctp_rs::{Cctp, CctpV2Bridge, PollingConfig};
+use tracing::field::{Field, Visit};
+use tracing::span::Record;
+use tracing_subscriber::layer::{Context, SubscriberExt};
+use tracing_subscriber::registry::LookupSpan;
+use tracing_subscriber::{Layer, Registry};
+use url::Url;
+use wiremock::matchers::method;
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+#[derive(Debug, Clone)]
+struct CapturedField {
+    span_name: String,
+    field: String,
+    value: String,
+}
+
+struct FieldRecordCaptureLayer {
+    records: Arc<Mutex<Vec<CapturedField>>>,
+}
+
+impl<S> Layer<S> for FieldRecordCaptureLayer
+where
+    S: tracing::Subscriber + for<'a> LookupSpan<'a>,
+{
+    fn on_record(&self, id: &tracing::span::Id, values: &Record<'_>, ctx: Context<'_, S>) {
+        let Some(span) = ctx.span(id) else {
+            return;
+        };
+        let span_name = span.name().to_string();
+        let mut sink = self.records.lock().unwrap();
+        let mut visitor = FieldVisitor {
+            records: &mut sink,
+            span_name,
+        };
+        values.record(&mut visitor);
+    }
+}
+
+struct FieldVisitor<'a> {
+    records: &'a mut Vec<CapturedField>,
+    span_name: String,
+}
+
+impl Visit for FieldVisitor<'_> {
+    fn record_str(&mut self, field: &Field, value: &str) {
+        self.records.push(CapturedField {
+            span_name: self.span_name.clone(),
+            field: field.name().to_string(),
+            value: value.to_string(),
+        });
+    }
+
+    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+        self.records.push(CapturedField {
+            span_name: self.span_name.clone(),
+            field: field.name().to_string(),
+            value: format!("{value:?}"),
+        });
+    }
+}
+
+fn install_record_subscriber() -> (
+    Arc<Mutex<Vec<CapturedField>>>,
+    tracing::subscriber::DefaultGuard,
+) {
+    let records = Arc::new(Mutex::new(Vec::new()));
+    let layer = FieldRecordCaptureLayer {
+        records: records.clone(),
+    };
+    let subscriber = Registry::default().with(layer);
+    let guard = tracing::subscriber::set_default(subscriber);
+    (records, guard)
+}
+
+fn dummy_provider() -> impl Provider<Ethereum> + Clone {
+    ProviderBuilder::new().connect_http("http://127.0.0.1:1/".parse().unwrap())
+}
+
+fn assert_field_recorded(
+    records: &[CapturedField],
+    expected_span: &str,
+    expected_field: &str,
+    expected_value: &str,
+) {
+    let matched = records.iter().any(|r| {
+        r.span_name == expected_span && r.field == expected_field && r.value == expected_value
+    });
+    assert!(
+        matched,
+        "expected span `{expected_span}` to record field `{expected_field}={expected_value}`, \
+         but no such record was observed. Captured records: {records:#?}"
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn v1_process_response_span_records_attestation_failed() {
+    let (records, _guard) = install_record_subscriber();
+
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "status": "failed"
+        })))
+        .mount(&server)
+        .await;
+
+    let api_override = Url::parse(&server.uri()).expect("wiremock URI parses as Url");
+    let provider = dummy_provider();
+    let bridge = Cctp::builder()
+        .source_chain(NamedChain::Mainnet)
+        .destination_chain(NamedChain::Arbitrum)
+        .source_provider(provider.clone())
+        .destination_provider(provider)
+        .recipient(Address::ZERO)
+        .api_url_override(api_override)
+        .build();
+
+    let result = bridge
+        .get_attestation(
+            FixedBytes::from([0x12u8; 32]),
+            PollingConfig::default()
+                .with_max_attempts(1)
+                .with_poll_interval_secs(1),
+        )
+        .await;
+    assert!(result.is_err(), "expected polling to fail on failed status");
+
+    let captured = records.lock().unwrap();
+    assert_field_recorded(
+        &captured,
+        "cctp_rs.process_attestation_response",
+        "error.type",
+        "AttestationFailed",
+    );
+    assert_field_recorded(
+        &captured,
+        "cctp_rs.process_attestation_response",
+        "otel.status_code",
+        "ERROR",
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn v1_attempt_span_records_http_request_failed() {
+    let (records, _guard) = install_record_subscriber();
+
+    let unreachable = Url::parse("http://127.0.0.1:1/").expect("static url");
+    let provider = dummy_provider();
+    let bridge = Cctp::builder()
+        .source_chain(NamedChain::Mainnet)
+        .destination_chain(NamedChain::Arbitrum)
+        .source_provider(provider.clone())
+        .destination_provider(provider)
+        .recipient(Address::ZERO)
+        .api_url_override(unreachable)
+        .build();
+
+    let result = bridge
+        .get_attestation(
+            FixedBytes::from([0x12u8; 32]),
+            PollingConfig::default()
+                .with_max_attempts(1)
+                .with_poll_interval_secs(1),
+        )
+        .await;
+    assert!(
+        result.is_err(),
+        "expected polling to fail against unreachable host"
+    );
+
+    let captured = records.lock().unwrap();
+    assert_field_recorded(
+        &captured,
+        "cctp_rs.get_attestation",
+        "error.type",
+        "HttpRequestFailed",
+    );
+    assert_field_recorded(
+        &captured,
+        "cctp_rs.get_attestation",
+        "otel.status_code",
+        "ERROR",
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn v2_process_response_span_records_attestation_failed() {
+    let (records, _guard) = install_record_subscriber();
+
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "messages": [
+                { "status": "failed" }
+            ]
+        })))
+        .mount(&server)
+        .await;
+
+    let api_override = Url::parse(&server.uri()).expect("wiremock URI parses as Url");
+    let provider = dummy_provider();
+    let bridge = CctpV2Bridge::builder()
+        .source_chain(NamedChain::Mainnet)
+        .destination_chain(NamedChain::Linea)
+        .source_provider(provider.clone())
+        .destination_provider(provider)
+        .recipient(Address::ZERO)
+        .api_url_override(api_override)
+        .build();
+
+    let result = bridge
+        .get_attestation(
+            FixedBytes::from([0xabu8; 32]),
+            PollingConfig::fast_transfer()
+                .with_max_attempts(1)
+                .with_poll_interval_secs(1),
+        )
+        .await;
+    assert!(result.is_err(), "expected polling to fail on failed status");
+
+    let captured = records.lock().unwrap();
+    assert_field_recorded(
+        &captured,
+        "cctp_rs.process_attestation_response",
+        "error.type",
+        "AttestationFailed",
+    );
+    assert_field_recorded(
+        &captured,
+        "cctp_rs.process_attestation_response",
+        "otel.status_code",
+        "ERROR",
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn v2_attempt_span_records_http_request_failed() {
+    let (records, _guard) = install_record_subscriber();
+
+    let unreachable = Url::parse("http://127.0.0.1:1/").expect("static url");
+    let provider = dummy_provider();
+    let bridge = CctpV2Bridge::builder()
+        .source_chain(NamedChain::Mainnet)
+        .destination_chain(NamedChain::Linea)
+        .source_provider(provider.clone())
+        .destination_provider(provider)
+        .recipient(Address::ZERO)
+        .api_url_override(unreachable)
+        .build();
+
+    let result = bridge
+        .get_attestation(
+            FixedBytes::from([0xabu8; 32]),
+            PollingConfig::fast_transfer()
+                .with_max_attempts(1)
+                .with_poll_interval_secs(1),
+        )
+        .await;
+    assert!(
+        result.is_err(),
+        "expected polling to fail against unreachable host"
+    );
+
+    let captured = records.lock().unwrap();
+    assert_field_recorded(
+        &captured,
+        "cctp_rs.get_attestation",
+        "error.type",
+        "HttpRequestFailed",
+    );
+    assert_field_recorded(
+        &captured,
+        "cctp_rs.get_attestation",
+        "otel.status_code",
+        "ERROR",
+    );
+}


### PR DESCRIPTION
## Summary

`tracing::Span::record` silently drops writes for fields that were never declared at span creation. The per-attempt and per-response spans inside the v1/v2 attestation polling loops omitted `error.type`, `error.message`, `error.context`, and `otel.status_code`, so the `record_error_with_context` writes for `HttpRequestFailed`, `AttestationFailed`, `AttestationDataMissing`, and `MessageDataMissing` never landed on any span — operators querying Tempo/Jaeger for these errors saw zero hits even while the SDK was emitting them in production. Closes #201.

## What's in the diff

- `src/spans.rs` — declare the four error fields (`error.type/message/context` as `field::Empty`; `otel.status_code` as `"OK"`) on `get_attestation` and `process_attestation_response`, matching the established pattern on `get_message_sent_event`, `get_attestation_with_retry`, etc.
- `tests/inner_span_error_attributes.rs` — new regression tests. Each test installs a `tracing_subscriber::Layer` that captures `Span::record` writes per span name, drives `get_attestation` against a failure scenario (`wiremock` returning `"failed"` for the process-span path; an unreachable host for the attempt-span path), and asserts the expected field landed on the expected inner span. Four tests cover v1/v2 × attempt-span/process-span. The tests fail RED on `main` (no records observed) and pass once the field declarations land.

## Acceptance check (from #201)

- [x] `record_error_with_context` writes for `HttpRequestFailed` now materialize on the per-attempt `cctp_rs.get_attestation` span (covered by `v{1,2}_attempt_span_records_http_request_failed`).
- [x] `record_error_with_context` writes for `AttestationFailed` / `AttestationDataMissing` / `MessageDataMissing` now materialize on the per-response `cctp_rs.process_attestation_response` span (covered by `v{1,2}_process_response_span_records_attestation_failed`; the missing-data paths share the same span and field-declaration site, so the same fix covers them).
- [x] Followed Option (1) from the issue's suggested-direction discussion — smaller change, aligns with the existing per-span declaration pattern.

## Test plan

- [x] `cargo nextest run --workspace --all-features` — 193/193 pass (including the four new tests).
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean.
- [x] `cargo fmt --check` clean.
- [x] Confirmed tests fail RED on the pre-fix `src/spans.rs` (all four panic with "no such record was observed").