### PR TITLE
test: lock in AttestationDataMissing and MessageDataMissing error.type strings

### DIFF
--- a/tests/inner_span_error_attributes.rs
+++ b/tests/inner_span_error_attributes.rs
@@ -215,6 +215,58 @@ async fn v1_attempt_span_records_http_request_failed() {
 }
 
 #[tokio::test(flavor = "current_thread")]
+async fn v1_process_response_span_records_attestation_data_missing() {
+    let (records, _guard) = install_record_subscriber();
+
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "status": "complete",
+            "attestation": null
+        })))
+        .mount(&server)
+        .await;
+
+    let api_override = Url::parse(&server.uri()).expect("wiremock URI parses as Url");
+    let provider = dummy_provider();
+    let bridge = Cctp::builder()
+        .source_chain(NamedChain::Mainnet)
+        .destination_chain(NamedChain::Arbitrum)
+        .source_provider(provider.clone())
+        .destination_provider(provider)
+        .recipient(Address::ZERO)
+        .api_url_override(api_override)
+        .build();
+
+    let result = bridge
+        .get_attestation(
+            FixedBytes::from([0x12u8; 32]),
+            PollingConfig::default()
+                .with_max_attempts(1)
+                .with_poll_interval_secs(1),
+        )
+        .await;
+    assert!(
+        result.is_err(),
+        "expected polling to fail on complete status with null attestation"
+    );
+
+    let captured = records.lock().unwrap();
+    assert_field_recorded(
+        &captured,
+        "cctp_rs.process_attestation_response",
+        "error.type",
+        "AttestationDataMissing",
+    );
+    assert_field_recorded(
+        &captured,
+        "cctp_rs.process_attestation_response",
+        "otel.status_code",
+        "ERROR",
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
 async fn v2_process_response_span_records_attestation_failed() {
     let (records, _guard) = install_record_subscriber();
 
@@ -302,6 +354,120 @@ async fn v2_attempt_span_records_http_request_failed() {
     assert_field_recorded(
         &captured,
         "cctp_rs.get_attestation",
+        "otel.status_code",
+        "ERROR",
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn v2_process_response_span_records_attestation_data_missing() {
+    let (records, _guard) = install_record_subscriber();
+
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "messages": [
+                {
+                    "status": "complete",
+                    "message": "0xdeadbeef",
+                    "attestation": null
+                }
+            ]
+        })))
+        .mount(&server)
+        .await;
+
+    let api_override = Url::parse(&server.uri()).expect("wiremock URI parses as Url");
+    let provider = dummy_provider();
+    let bridge = CctpV2Bridge::builder()
+        .source_chain(NamedChain::Mainnet)
+        .destination_chain(NamedChain::Linea)
+        .source_provider(provider.clone())
+        .destination_provider(provider)
+        .recipient(Address::ZERO)
+        .api_url_override(api_override)
+        .build();
+
+    let result = bridge
+        .get_attestation(
+            FixedBytes::from([0xabu8; 32]),
+            PollingConfig::fast_transfer()
+                .with_max_attempts(1)
+                .with_poll_interval_secs(1),
+        )
+        .await;
+    assert!(
+        result.is_err(),
+        "expected polling to fail on complete status with null attestation"
+    );
+
+    let captured = records.lock().unwrap();
+    assert_field_recorded(
+        &captured,
+        "cctp_rs.process_attestation_response",
+        "error.type",
+        "AttestationDataMissing",
+    );
+    assert_field_recorded(
+        &captured,
+        "cctp_rs.process_attestation_response",
+        "otel.status_code",
+        "ERROR",
+    );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn v2_process_response_span_records_message_data_missing() {
+    let (records, _guard) = install_record_subscriber();
+
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "messages": [
+                {
+                    "status": "complete",
+                    "message": null,
+                    "attestation": "0x1234abcd"
+                }
+            ]
+        })))
+        .mount(&server)
+        .await;
+
+    let api_override = Url::parse(&server.uri()).expect("wiremock URI parses as Url");
+    let provider = dummy_provider();
+    let bridge = CctpV2Bridge::builder()
+        .source_chain(NamedChain::Mainnet)
+        .destination_chain(NamedChain::Linea)
+        .source_provider(provider.clone())
+        .destination_provider(provider)
+        .recipient(Address::ZERO)
+        .api_url_override(api_override)
+        .build();
+
+    let result = bridge
+        .get_attestation(
+            FixedBytes::from([0xabu8; 32]),
+            PollingConfig::fast_transfer()
+                .with_max_attempts(1)
+                .with_poll_interval_secs(1),
+        )
+        .await;
+    assert!(
+        result.is_err(),
+        "expected polling to fail on complete status with null message"
+    );
+
+    let captured = records.lock().unwrap();
+    assert_field_recorded(
+        &captured,
+        "cctp_rs.process_attestation_response",
+        "error.type",
+        "MessageDataMissing",
+    );
+    assert_field_recorded(
+        &captured,
+        "cctp_rs.process_attestation_response",
         "otel.status_code",
         "ERROR",
     );


### PR DESCRIPTION
## Summary

The inner-span `error.type` literals operators query in TraceQL alerts —
`AttestationDataMissing` (v1 and v2) and `MessageDataMissing` (v2) — were
previously unprotected. A future rename, casing change, or stray whitespace in
`bridge::attestation_data_missing()` or the v2 inline message-missing closure
would compile and pass the existing suite while silently breaking production
alerts like `{ span.error.type = "AttestationDataMissing" }`. Closes #208.

## What's in the diff

- `tests/inner_span_error_attributes.rs` — three new wiremock-backed
  `#[tokio::test(flavor = "current_thread")]` cases following the established
  `*_attestation_failed` pattern:
  - `v1_process_response_span_records_attestation_data_missing` drives `Cctp`
    against `{"status": "complete", "attestation": null}`.
  - `v2_process_response_span_records_attestation_data_missing` drives
    `CctpV2Bridge` against a single-message response with attestation null and
    message set.
  - `v2_process_response_span_records_message_data_missing` drives
    `CctpV2Bridge` against a single-message response with attestation set and
    message null (attestation is checked first in `bridge/v2.rs`, so the
    payload pins evaluation onto the message branch).

  Each asserts the exact `error.type` literal and `otel.status_code = "ERROR"`
  on the `cctp_rs.process_attestation_response` span.

## Acceptance check (from #208)

- [x] v1 case: complete-status with null attestation → asserts `error.type = "AttestationDataMissing"` on the process-response span.
- [x] v2 case: complete-status message with null attestation → asserts `AttestationDataMissing` on the same span.
- [x] v2 case: complete-status message with null message → asserts `MessageDataMissing` on the same span.
- [x] Sits alongside the existing `*_process_response_span_records_attestation_failed` pair as a localized extension, not new infrastructure.

The broader sweep (`ReceiptRetrievalFailed`, `MessageSentEventNotFound`,
`TransactionNotFound`, `HttpRequestFailed`, `AttestationTimeout`,
`UnsupportedChain`) is intentionally out of scope and remains for a separate
issue per #208's framing.

## Test plan

- [x] `cargo nextest run --test inner_span_error_attributes --all-features` — 7/7 pass (4 existing + 3 new)
- [x] `cargo nextest run --workspace --lib --bins --all-features` — 187/187 pass
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] commit signed (verified `git log --show-signature`)