### PR TITLE
refactor: dedupe Iris API base-URL selection across CCTP v1 and v2

### DIFF
--- a/src/bridge/cctp.rs
+++ b/src/bridge/cctp.rs
@@ -19,7 +19,7 @@ use tracing::{debug, error, info, Instrument};
 use url::Url;
 
 use super::bridge_trait::CctpBridge;
-use super::config::{PollingConfig, ATTESTATION_PATH_V1, IRIS_API, IRIS_API_SANDBOX};
+use super::config::{iris_api_url, PollingConfig, ATTESTATION_PATH_V1};
 use crate::contracts::message_transmitter::MessageTransmitter::MessageSent;
 use crate::protocol::FinalityThreshold;
 
@@ -66,11 +66,7 @@ impl<P: Provider<Ethereum> + Clone> Cctp<P> {
         if let Some(url) = &self.api_url_override {
             return url.clone();
         }
-        if self.source_chain.is_testnet() {
-            Url::parse(IRIS_API_SANDBOX).unwrap()
-        } else {
-            Url::parse(IRIS_API).unwrap()
-        }
+        iris_api_url(self.source_chain)
     }
 
     /// Returns the source chain
@@ -473,6 +469,7 @@ impl<P: Provider<Ethereum> + Clone> CctpBridge for Cctp<P> {
 
 #[cfg(test)]
 mod tests {
+    use super::super::config::{IRIS_API, IRIS_API_SANDBOX};
     use super::*;
     use alloy_chains::NamedChain;
     use alloy_primitives::{Address, FixedBytes};

--- a/src/bridge/config.rs
+++ b/src/bridge/config.rs
@@ -2,7 +2,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+use alloy_chains::NamedChain;
 use serde::{Deserialize, Serialize};
+use url::Url;
 
 /// Circle Iris API environment URLs
 ///
@@ -10,6 +12,18 @@ use serde::{Deserialize, Serialize};
 ///
 pub const IRIS_API: &str = "https://iris-api.circle.com";
 pub const IRIS_API_SANDBOX: &str = "https://iris-api-sandbox.circle.com";
+
+/// Returns the Iris API base URL for the given chain.
+///
+/// Selects [`IRIS_API_SANDBOX`] when `chain` is a testnet and [`IRIS_API`]
+/// otherwise.
+pub fn iris_api_url(chain: NamedChain) -> Url {
+    if chain.is_testnet() {
+        Url::parse(IRIS_API_SANDBOX).unwrap()
+    } else {
+        Url::parse(IRIS_API).unwrap()
+    }
+}
 
 /// CCTP v1 attestation API path
 pub const ATTESTATION_PATH_V1: &str = "/v1/attestations/";

--- a/src/bridge/v2.rs
+++ b/src/bridge/v2.rs
@@ -34,7 +34,7 @@ pub enum MintResult {
 }
 
 use super::bridge_trait::CctpBridge;
-use super::config::{PollingConfig, IRIS_API, IRIS_API_SANDBOX, MESSAGES_PATH_V2};
+use super::config::{iris_api_url, PollingConfig, MESSAGES_PATH_V2};
 use crate::contracts::erc20::Erc20Contract;
 use crate::contracts::message_transmitter::MessageTransmitter::MessageSent;
 use crate::contracts::v2::{MessageTransmitterV2Contract, TokenMessengerV2Contract};
@@ -115,11 +115,7 @@ impl<P: Provider<Ethereum> + Clone> CctpV2<P> {
         if let Some(url) = &self.api_url_override {
             return url.clone();
         }
-        if self.source_chain.is_testnet() {
-            Url::parse(IRIS_API_SANDBOX).unwrap()
-        } else {
-            Url::parse(IRIS_API).unwrap()
-        }
+        iris_api_url(self.source_chain)
     }
 
     /// Returns the source chain


### PR DESCRIPTION
## Summary

`Cctp::api_url` and `CctpV2::api_url` both inlined the same testnet-vs-mainnet branch over the `IRIS_API` / `IRIS_API_SANDBOX` constants, re-parsing one of them on every call. This lifts that branch into a single `iris_api_url(chain: NamedChain) -> Url` helper in `bridge::config` and has both methods delegate to it after the existing `api_url_override` check, so the source of truth for which Iris environment a chain talks to lives in one place. Closes #186.

## What's in the diff

- `src/bridge/config.rs` — new `pub fn iris_api_url(chain) -> Url` (crate-private; `config` module is not re-exported), built on the same `IRIS_API` / `IRIS_API_SANDBOX` constants.
- `src/bridge/cctp.rs` — `Cctp::api_url` collapses to `iris_api_url(self.source_chain)` after the override guard. The `IRIS_API` / `IRIS_API_SANDBOX` imports move into the `#[cfg(test)] mod tests` block where the existing `starts_with(IRIS_API*)` assertions need them.
- `src/bridge/v2.rs` — `CctpV2::api_url` collapses to the same call. `IRIS_API` / `IRIS_API_SANDBOX` imports drop entirely (v2 tests assert against host string literals).

Public method signatures, override semantics, and return values are unchanged.

## Acceptance check (from #186)

- [x] Free function `iris_api_url(chain) -> Url` lives in `bridge/config.rs`, branching on `chain.is_testnet()`.
- [x] Both `api_url` methods collapse to `iris_api_url(self.source_chain)` (preserving the override branch each method already had).
- [x] Public method signatures unchanged — non-breaking refactor.

## Test plan

- [x] `cargo nextest run --workspace --all-features` — 196/196 pass
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt` clean