### PR TITLE
fix: reject zero polling values and saturate timeout math

### DIFF
--- a/src/bridge/cctp.rs
+++ b/src/bridge/cctp.rs
@@ -243,8 +243,10 @@ impl<P: Provider<Ethereum> + Clone> Cctp<P> {
         message_hash: FixedBytes<32>,
         polling_config: PollingConfig,
     ) -> Result<AttestationBytes> {
+        polling_config.validate()?;
         let max_attempts = polling_config.max_attempts;
         let poll_interval = polling_config.poll_interval_secs;
+        let total_timeout_secs = polling_config.total_timeout_secs();
 
         let span = spans::get_attestation_with_retry(
             &message_hash,
@@ -367,13 +369,10 @@ impl<P: Provider<Ethereum> + Clone> Cctp<P> {
             spans::record_error_with_context(
                 "AttestationTimeout",
                 &format!("Attestation polling timed out after {max_attempts} attempts"),
-                Some(&format!(
-                    "Total duration: {} seconds",
-                    u64::from(max_attempts) * poll_interval
-                )),
+                Some(&format!("Total duration: {total_timeout_secs} seconds")),
             );
             error!(
-                total_duration_secs = u64::from(max_attempts) * poll_interval,
+                total_duration_secs = total_timeout_secs,
                 event = "attestation_timeout"
             );
             Err(CctpError::AttestationTimeout)

--- a/src/bridge/config.rs
+++ b/src/bridge/config.rs
@@ -6,6 +6,8 @@ use alloy_chains::NamedChain;
 use serde::{Deserialize, Serialize};
 use url::Url;
 
+use crate::error::{CctpError, Result};
+
 /// Circle Iris API environment URLs
 ///
 /// See <https://developers.circle.com/stablecoins/cctp-apis>
@@ -95,6 +97,64 @@ impl PollingConfig {
         }
     }
 
+    /// Creates a polling configuration after checking that both fields are
+    /// usable for polling.
+    ///
+    /// Rejects `max_attempts = 0` (which would time out immediately) and
+    /// `poll_interval_secs = 0` (which would spin a tight retry loop).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CctpError::InvalidConfig`] when either input is zero.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use cctp_rs::PollingConfig;
+    ///
+    /// let config = PollingConfig::try_new(20, 30).unwrap();
+    /// assert_eq!(config.max_attempts, 20);
+    /// assert_eq!(config.poll_interval_secs, 30);
+    ///
+    /// assert!(PollingConfig::try_new(0, 30).is_err());
+    /// assert!(PollingConfig::try_new(20, 0).is_err());
+    /// ```
+    pub fn try_new(max_attempts: u32, poll_interval_secs: u64) -> Result<Self> {
+        let config = Self {
+            max_attempts,
+            poll_interval_secs,
+        };
+        config.validate()?;
+        Ok(config)
+    }
+
+    /// Validates the configuration for use in polling loops.
+    ///
+    /// Builder methods like [`Self::with_max_attempts`] and
+    /// [`Self::with_poll_interval_secs`] do not check their inputs, so callers
+    /// that accept the values at runtime should call this before using the
+    /// config to poll Circle's Iris API.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CctpError::InvalidConfig`] when `max_attempts` is zero
+    /// (the polling loop would exit before its first request) or
+    /// `poll_interval_secs` is zero (the loop would never sleep between
+    /// retries).
+    pub fn validate(&self) -> Result<()> {
+        if self.max_attempts == 0 {
+            return Err(CctpError::InvalidConfig(
+                "PollingConfig.max_attempts must be greater than 0".to_string(),
+            ));
+        }
+        if self.poll_interval_secs == 0 {
+            return Err(CctpError::InvalidConfig(
+                "PollingConfig.poll_interval_secs must be greater than 0".to_string(),
+            ));
+        }
+        Ok(())
+    }
+
     /// Sets the maximum number of polling attempts.
     ///
     /// # Arguments
@@ -135,7 +195,9 @@ impl PollingConfig {
 
     /// Returns the total maximum wait time in seconds.
     ///
-    /// This is calculated as `max_attempts * poll_interval_secs`.
+    /// Computed as `max_attempts * poll_interval_secs` with saturating
+    /// arithmetic, so pathological large values clamp to [`u64::MAX`] instead
+    /// of overflowing.
     ///
     /// # Example
     ///
@@ -146,7 +208,7 @@ impl PollingConfig {
     /// assert_eq!(config.total_timeout_secs(), 30 * 60); // 30 minutes
     /// ```
     pub fn total_timeout_secs(&self) -> u64 {
-        u64::from(self.max_attempts) * self.poll_interval_secs
+        u64::from(self.max_attempts).saturating_mul(self.poll_interval_secs)
     }
 }
 
@@ -185,5 +247,65 @@ mod tests {
         let config = PollingConfig::default();
         let copied = config;
         assert_eq!(config, copied);
+    }
+
+    #[test]
+    fn test_validate_accepts_defaults() {
+        assert!(PollingConfig::default().validate().is_ok());
+        assert!(PollingConfig::fast_transfer().validate().is_ok());
+    }
+
+    #[test]
+    fn test_validate_rejects_zero_max_attempts() {
+        let config = PollingConfig::default().with_max_attempts(0);
+        let err = config.validate().unwrap_err();
+        assert!(
+            matches!(err, CctpError::InvalidConfig(ref msg) if msg.contains("max_attempts")),
+            "expected InvalidConfig mentioning max_attempts, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_validate_rejects_zero_poll_interval() {
+        let config = PollingConfig::default().with_poll_interval_secs(0);
+        let err = config.validate().unwrap_err();
+        assert!(
+            matches!(err, CctpError::InvalidConfig(ref msg) if msg.contains("poll_interval_secs")),
+            "expected InvalidConfig mentioning poll_interval_secs, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_try_new_accepts_positive_values() {
+        let config = PollingConfig::try_new(20, 30).unwrap();
+        assert_eq!(config.max_attempts, 20);
+        assert_eq!(config.poll_interval_secs, 30);
+    }
+
+    #[test]
+    fn test_try_new_rejects_zero_inputs() {
+        assert!(PollingConfig::try_new(0, 30).is_err());
+        assert!(PollingConfig::try_new(20, 0).is_err());
+        assert!(PollingConfig::try_new(0, 0).is_err());
+    }
+
+    #[test]
+    fn test_total_timeout_saturates_on_overflow() {
+        let config = PollingConfig {
+            max_attempts: u32::MAX,
+            poll_interval_secs: u64::MAX,
+        };
+        // u32::MAX * u64::MAX would overflow; saturating arithmetic clamps it.
+        assert_eq!(config.total_timeout_secs(), u64::MAX);
+    }
+
+    #[test]
+    fn test_total_timeout_with_large_in_range_values() {
+        // 1_000_000 attempts * 3600 secs = 3.6e9, fits comfortably in u64.
+        let config = PollingConfig {
+            max_attempts: 1_000_000,
+            poll_interval_secs: 3600,
+        };
+        assert_eq!(config.total_timeout_secs(), 3_600_000_000);
     }
 }

--- a/src/bridge/v2.rs
+++ b/src/bridge/v2.rs
@@ -342,8 +342,10 @@ impl<P: Provider<Ethereum> + Clone> CctpV2<P> {
         tx_hash: TxHash,
         polling_config: PollingConfig,
     ) -> Result<(Vec<u8>, AttestationBytes)> {
+        polling_config.validate()?;
         let max_attempts = polling_config.max_attempts;
         let poll_interval = polling_config.poll_interval_secs;
+        let total_timeout_secs = polling_config.total_timeout_secs();
 
         let span = spans::get_v2_attestation_with_retry(
             tx_hash,
@@ -500,13 +502,10 @@ impl<P: Provider<Ethereum> + Clone> CctpV2<P> {
             spans::record_error_with_context(
                 "AttestationTimeout",
                 &format!("Attestation polling timed out after {max_attempts} attempts"),
-                Some(&format!(
-                    "Total duration: {} seconds",
-                    u64::from(max_attempts) * poll_interval
-                )),
+                Some(&format!("Total duration: {total_timeout_secs} seconds")),
             );
             error!(
-                total_duration_secs = u64::from(max_attempts) * poll_interval,
+                total_duration_secs = total_timeout_secs,
                 event = "attestation_timeout"
             );
             Err(CctpError::AttestationTimeout)
@@ -743,13 +742,16 @@ impl<P: Provider<Ethereum> + Clone> CctpV2<P> {
     /// # Arguments
     ///
     /// * `message` - The canonical message bytes (from [`Self::get_attestation`])
-    /// * `max_attempts` - Maximum polling attempts (default: 60)
-    /// * `poll_interval` - Seconds between polls (default: based on transfer type and chain)
+    /// * `max_attempts` - Maximum polling attempts (default: 60). `Some(0)` is
+    ///   rejected with [`CctpError::InvalidConfig`].
+    /// * `poll_interval` - Seconds between polls (default: based on transfer
+    ///   type and chain). `Some(0)` is rejected with [`CctpError::InvalidConfig`].
     ///
     /// # Returns
     ///
     /// * `Ok(())` when the message has been received
     /// * `Err(CctpError::AttestationTimeout)` if max attempts exceeded
+    /// * `Err(CctpError::InvalidConfig)` if either input is `Some(0)`
     ///
     /// # Example
     ///
@@ -770,6 +772,17 @@ impl<P: Provider<Ethereum> + Clone> CctpV2<P> {
         max_attempts: Option<u32>,
         poll_interval: Option<u64>,
     ) -> Result<()> {
+        if matches!(max_attempts, Some(0)) {
+            return Err(CctpError::InvalidConfig(
+                "wait_for_receive max_attempts must be greater than 0".to_string(),
+            ));
+        }
+        if matches!(poll_interval, Some(0)) {
+            return Err(CctpError::InvalidConfig(
+                "wait_for_receive poll_interval must be greater than 0".to_string(),
+            ));
+        }
+
         let max_attempts = max_attempts.unwrap_or(60);
         let poll_interval = poll_interval.unwrap_or_else(|| {
             if self.fast_transfer {


### PR DESCRIPTION
## Summary

`PollingConfig` previously accepted `max_attempts = 0` (immediate timeout
before the first request) and `poll_interval_secs = 0` (tight retry
loop), and the timeout error path used unchecked multiplication.
Operators that wire these from runtime config now get a clear
`CctpError::InvalidConfig` instead of a silently broken poll, and the
timeout duration logged on failure can no longer overflow.

Closes #220.

## What's in the diff

- `src/bridge/config.rs` — adds `PollingConfig::try_new` (checked
  constructor) and `PollingConfig::validate`, and converts
  `total_timeout_secs` to saturating multiplication. Tests cover both
  the zero-rejection paths and the saturating-overflow case.
- `src/bridge/cctp.rs` / `src/bridge/v2.rs` — call `validate()?` at the
  top of each `get_attestation` before any polling work, and pull the
  timeout-log duration from the safe `total_timeout_secs()`.
- `src/bridge/v2.rs::wait_for_receive` — rejects `Some(0)` for both
  `max_attempts` and `poll_interval` with `CctpError::InvalidConfig`
  before falling through to the chain-derived defaults. Docs updated to
  call out the new error case.

## Acceptance check (from #220)

- [x] Checked constructor / validation method for runtime inputs — `PollingConfig::try_new` and `PollingConfig::validate`.
- [x] Reject zero `max_attempts` and zero `poll_interval_secs` where polling is expected — covered in v1/v2 `get_attestation` and `wait_for_receive`.
- [x] Use checked or saturating multiplication for total timeout display — `total_timeout_secs` now uses `saturating_mul`, and both timeout-error paths route through it.
- [x] Tests for zero and large values — new unit tests in `src/bridge/config.rs` for zero rejection, large in-range values, and `u32::MAX` × `u64::MAX` saturation.

## Test plan

- [x] `cargo nextest run --lib --bins --all-features` — 194/194 pass
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo test --doc --all-features` — 27/27 pass (new `try_new` doctest included)