### PR TITLE
refactor: make v2 transfer mode explicit and align reported finality with the wire

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- New `TransferMode` enum that names the four valid CCTP v2 burn
+  configurations (`Standard`, `Fast { max_fee }`,
+  `StandardWithHook { hook_data }`,
+  `FastWithHook { max_fee, hook_data }`). Selected via a single
+  `transfer_mode` builder field on `CctpV2Bridge`.
+- `CctpV2Bridge::transfer_mode()` accessor.
+
+### Changed
+
+- **Breaking:** `CctpV2Bridge::builder()` no longer accepts the
+  independent `fast_transfer(bool)`, `hook_data(Bytes)`, and
+  `max_fee(U256)` fields. Use `transfer_mode(TransferMode::…)`
+  instead. The `is_fast_transfer()`, `hook_data()`, `max_fee()`, and
+  `finality_threshold()` accessors are preserved and now derive from
+  the configured mode. Note that `max_fee()` returns
+  `Some(U256::ZERO)` (not `None`) for `TransferMode::Fast { max_fee:
+  U256::ZERO }` and `TransferMode::FastWithHook { max_fee:
+  U256::ZERO, .. }` — the prior shape always returned `None` when
+  the optional `.max_fee(...)` builder method was unset.
+- **Breaking:**
+  `TokenMessengerV2Contract::deposit_for_burn_with_hooks_transaction`
+  now takes `max_fee: U256` and `min_finality_threshold: u32`
+  arguments. The previous signature hardcoded standard finality with
+  zero fee, which excluded the hook + fast-finality burn that
+  Circle's `depositForBurnWithHook` supports natively.
+
+### Fixed
+
+- Fast transfer + hook configurations now actually send a
+  fast-finality burn on-chain. Previous versions silently fell back
+  to the standard-finality hook path while still reporting
+  `FinalityThreshold::Fast` from `finality_threshold()`, so the
+  reported mode and the transmitted `minFinalityThreshold` (and
+  `maxFee`) diverged. The accessor result and the burn now agree by
+  construction. Tracks issue #218.
+
 ## [5.2.0] - 2026-05-24
 
 ### Added

--- a/examples/v2_fast_transfer.rs
+++ b/examples/v2_fast_transfer.rs
@@ -26,7 +26,7 @@ use alloy_network::EthereumWallet;
 use alloy_primitives::{address, U256};
 use alloy_provider::{Provider, ProviderBuilder};
 use alloy_signer_local::PrivateKeySigner;
-use cctp_rs::{CctpError, CctpV2, CctpV2Bridge, Erc20Contract};
+use cctp_rs::{CctpError, CctpV2, CctpV2Bridge, Erc20Contract, TransferMode};
 use dotenvy::dotenv;
 use tracing::{info_span, Instrument};
 
@@ -255,8 +255,7 @@ async fn main() -> Result<(), CctpError> {
         .source_provider(arbitrum_sepolia_provider)
         .destination_provider(base_sepolia_provider)
         .recipient(wallet_address)
-        .fast_transfer(true) // Enable fast transfers!
-        .max_fee(max_fee) // Optional: set maximum fee willing to pay
+        .transfer_mode(TransferMode::Fast { max_fee }) // <30s settlement, capped fee
         .build();
 
     println!("   ✅ Fast transfer bridge created\n");

--- a/examples/v2_integration_validation.rs
+++ b/examples/v2_integration_validation.rs
@@ -13,7 +13,7 @@
 use alloy_chains::NamedChain;
 use alloy_primitives::{Address, Bytes, U256};
 use alloy_provider::ProviderBuilder;
-use cctp_rs::{CctpV2, CctpV2Bridge, DomainId};
+use cctp_rs::{CctpV2, CctpV2Bridge, DomainId, TransferMode};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -290,8 +290,9 @@ fn validate_bridge_configurations() -> Result<(), Box<dyn std::error::Error>> {
         .source_provider(provider.clone())
         .destination_provider(provider.clone())
         .recipient(Address::ZERO)
-        .fast_transfer(true)
-        .max_fee(U256::from(1000))
+        .transfer_mode(TransferMode::Fast {
+            max_fee: U256::from(1000),
+        })
         .build();
 
     assert!(
@@ -309,8 +310,8 @@ fn validate_bridge_configurations() -> Result<(), Box<dyn std::error::Error>> {
     println!("   ✓ Max fee: 1000 (0.001 USDC)");
     println!("   ✓ Hooks: None\n");
 
-    // Test 3: With Hooks
-    println!("   With Hooks:");
+    // Test 3: Standard + Hooks
+    println!("   Standard + Hooks:");
     let hook_data = Bytes::from(vec![0xde, 0xad, 0xbe, 0xef]);
     let hooks = CctpV2Bridge::builder()
         .source_chain(NamedChain::Mainnet)
@@ -318,12 +319,14 @@ fn validate_bridge_configurations() -> Result<(), Box<dyn std::error::Error>> {
         .source_provider(provider.clone())
         .destination_provider(provider.clone())
         .recipient(Address::ZERO)
-        .hook_data(hook_data.clone())
+        .transfer_mode(TransferMode::StandardWithHook {
+            hook_data: hook_data.clone(),
+        })
         .build();
 
     assert!(
         !hooks.is_fast_transfer(),
-        "Hooks (standard) should not be fast"
+        "StandardWithHook should not be fast"
     );
     assert_eq!(hooks.hook_data(), Some(&hook_data));
     assert_eq!(hooks.finality_threshold().as_u32(), 2000);
@@ -332,17 +335,18 @@ fn validate_bridge_configurations() -> Result<(), Box<dyn std::error::Error>> {
     println!("   ✓ Hooks: Present (4 bytes)");
     println!("   ✓ Hook data: 0xdeadbeef\n");
 
-    // Test 4: Fast + Hooks (priority test)
-    println!("   Fast + Hooks (priority test):");
+    // Test 4: Fast + Hooks
+    println!("   Fast + Hooks:");
     let fast_hooks = CctpV2Bridge::builder()
         .source_chain(NamedChain::Mainnet)
         .destination_chain(NamedChain::Linea)
         .source_provider(provider.clone())
         .destination_provider(provider)
         .recipient(Address::ZERO)
-        .fast_transfer(true)
-        .max_fee(U256::from(1000))
-        .hook_data(hook_data.clone())
+        .transfer_mode(TransferMode::FastWithHook {
+            max_fee: U256::from(1000),
+            hook_data: hook_data.clone(),
+        })
         .build();
 
     assert!(fast_hooks.is_fast_transfer(), "Should have fast_transfer");
@@ -354,12 +358,13 @@ fn validate_bridge_configurations() -> Result<(), Box<dyn std::error::Error>> {
     assert_eq!(
         fast_hooks.finality_threshold().as_u32(),
         1000,
-        "Fast takes priority"
+        "FastWithHook reports — and sends — fast finality"
     );
+    assert_eq!(fast_hooks.max_fee(), Some(U256::from(1000)));
     println!("   ✓ Finality: 1000 (fast finality with hooks)");
     println!("   ✓ Fast transfer: enabled");
     println!("   ✓ Hooks: Present");
-    println!("   ✓ Priority: Fast finality + hooks both active\n");
+    println!("   ✓ Max fee: 1000 (passed through with hook)\n");
 
     Ok(())
 }

--- a/examples/v2_standard_transfer.rs
+++ b/examples/v2_standard_transfer.rs
@@ -53,7 +53,7 @@ async fn main() -> Result<(), CctpError> {
         .source_provider(eth_provider)
         .destination_provider(linea_provider)
         .recipient(recipient)
-        // No fast_transfer flag = standard transfer
+        // Default transfer mode = TransferMode::Standard
         .build();
 
     println!("   ✅ Bridge created successfully\n");
@@ -164,8 +164,10 @@ async fn main() -> Result<(), CctpError> {
     println!("8️⃣ V2 Standard Transfer vs V1:");
     println!("   ✅ Unified contract addresses across chains");
     println!("   ✅ Explicit finality threshold (2000 = finalized)");
-    println!("   ✅ Support for fast transfers (with fast_transfer flag)");
-    println!("   ✅ Support for programmable hooks (with hook_data)");
+    println!("   ✅ Support for fast transfers (TransferMode::Fast)");
+    println!(
+        "   ✅ Support for programmable hooks (TransferMode::StandardWithHook / FastWithHook)"
+    );
     println!("   ✅ Same security level as v1 (finalized blocks)");
     println!("   ✅ No fees for standard transfers\n");
 

--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -10,12 +10,14 @@ mod bridge_trait;
 mod cctp;
 mod config;
 pub mod multicall;
+mod transfer_mode;
 mod v2;
 
 pub use bridge_trait::CctpBridge;
 pub use cctp::Cctp;
 pub use config::PollingConfig;
 pub use multicall::{batch_token_state, TokenState};
+pub use transfer_mode::TransferMode;
 pub use v2::{CctpV2, MintResult};
 
 use crate::error::{AttestationFailureKind, CctpError};

--- a/src/bridge/transfer_mode.rs
+++ b/src/bridge/transfer_mode.rs
@@ -1,0 +1,200 @@
+// SPDX-FileCopyrightText: 2025 Semiotic AI, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//! CCTP v2 transfer mode selection.
+//!
+//! Circle's v2 `depositForBurn` family exposes two orthogonal choices: the
+//! finality threshold (fast vs. standard) and whether the burn carries hook
+//! data for a post-mint action on the destination chain. This module encodes
+//! the four valid combinations as a single enum so the mode is explicit at
+//! the API boundary instead of being inferred from independent flags.
+//!
+//! Both `depositForBurn` and `depositForBurnWithHook` accept `maxFee` and
+//! `minFinalityThreshold` on-chain, so pairing hooks with fast finality is
+//! supported by the protocol — see Circle's CCTP v2 reference at
+//! <https://developers.circle.com/cctp/evm-smart-contracts>.
+//!
+//! [`TransferMode::Standard`] is the default and incurs no fast-transfer fee.
+
+use alloy_primitives::{Bytes, U256};
+
+use crate::protocol::FinalityThreshold;
+
+/// Selects which CCTP v2 burn variant the bridge sends.
+///
+/// Replaces the legacy independent `fast_transfer` / `hook_data` / `max_fee`
+/// fields. The enum captures the exact wire shape of the four valid
+/// configurations and makes the relationship between fee, finality, and hook
+/// data unambiguous at the type level.
+///
+/// # Examples
+///
+/// ```rust
+/// use cctp_rs::{FinalityThreshold, TransferMode};
+/// use alloy_primitives::{Bytes, U256};
+///
+/// let standard = TransferMode::Standard;
+/// assert_eq!(standard.finality_threshold(), FinalityThreshold::Standard);
+/// assert!(standard.hook_data().is_none());
+///
+/// let fast = TransferMode::Fast { max_fee: U256::from(500) };
+/// assert_eq!(fast.finality_threshold(), FinalityThreshold::Fast);
+/// assert_eq!(fast.max_fee(), U256::from(500));
+///
+/// let fast_with_hook = TransferMode::FastWithHook {
+///     max_fee: U256::from(500),
+///     hook_data: Bytes::from(vec![0xde, 0xad]),
+/// };
+/// assert!(fast_with_hook.is_fast());
+/// assert_eq!(fast_with_hook.hook_data().map(|b| b.len()), Some(2));
+/// ```
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum TransferMode {
+    /// Plain burn at finalized finality (threshold 2000), no hooks.
+    ///
+    /// Settlement matches v1 timing (13–19 min). No fast-transfer fee.
+    #[default]
+    Standard,
+
+    /// Fast burn at confirmed finality (threshold 1000), no hooks.
+    ///
+    /// `max_fee` caps the fast-transfer fee Circle's relayers may deduct
+    /// from the minted amount. A fee below the chain's minimum will leave
+    /// the burn pending until enough finality accrues for the standard
+    /// path.
+    Fast {
+        /// Maximum fast-transfer fee, in USDC atomic units.
+        max_fee: U256,
+    },
+
+    /// Burn carrying hook data at finalized finality.
+    ///
+    /// The hook data is opaque to CCTP and runs on the destination chain
+    /// after the mint.
+    StandardWithHook {
+        /// Hook payload forwarded to the destination chain.
+        hook_data: Bytes,
+    },
+
+    /// Burn carrying hook data at confirmed (fast) finality.
+    ///
+    /// Combines a fast-finality attestation with a post-mint hook. Both
+    /// `maxFee` and `hookData` are passed through to
+    /// `depositForBurnWithHook` on-chain.
+    FastWithHook {
+        /// Maximum fast-transfer fee, in USDC atomic units.
+        max_fee: U256,
+        /// Hook payload forwarded to the destination chain.
+        hook_data: Bytes,
+    },
+}
+
+impl TransferMode {
+    /// Returns the finality threshold this mode requests from Circle.
+    #[inline]
+    #[must_use]
+    pub const fn finality_threshold(&self) -> FinalityThreshold {
+        match self {
+            Self::Standard | Self::StandardWithHook { .. } => FinalityThreshold::Standard,
+            Self::Fast { .. } | Self::FastWithHook { .. } => FinalityThreshold::Fast,
+        }
+    }
+
+    /// Returns `true` when the mode requests fast (confirmed) finality.
+    #[inline]
+    #[must_use]
+    pub const fn is_fast(&self) -> bool {
+        matches!(self, Self::Fast { .. } | Self::FastWithHook { .. })
+    }
+
+    /// Returns `true` when the mode carries hook data.
+    #[inline]
+    #[must_use]
+    pub const fn has_hook(&self) -> bool {
+        matches!(
+            self,
+            Self::StandardWithHook { .. } | Self::FastWithHook { .. }
+        )
+    }
+
+    /// Returns the fast-transfer fee cap.
+    ///
+    /// Defaults to `U256::ZERO` for standard modes, which is what the
+    /// on-chain call expects when fast transfer is not requested.
+    #[inline]
+    #[must_use]
+    pub fn max_fee(&self) -> U256 {
+        match self {
+            Self::Fast { max_fee } | Self::FastWithHook { max_fee, .. } => *max_fee,
+            Self::Standard | Self::StandardWithHook { .. } => U256::ZERO,
+        }
+    }
+
+    /// Returns the hook payload, if any.
+    #[inline]
+    #[must_use]
+    pub const fn hook_data(&self) -> Option<&Bytes> {
+        match self {
+            Self::StandardWithHook { hook_data } | Self::FastWithHook { hook_data, .. } => {
+                Some(hook_data)
+            }
+            Self::Standard | Self::Fast { .. } => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn standard_defaults() {
+        let mode = TransferMode::default();
+        assert_eq!(mode, TransferMode::Standard);
+        assert_eq!(mode.finality_threshold(), FinalityThreshold::Standard);
+        assert!(!mode.is_fast());
+        assert!(!mode.has_hook());
+        assert_eq!(mode.max_fee(), U256::ZERO);
+        assert!(mode.hook_data().is_none());
+    }
+
+    #[test]
+    fn fast_carries_fee() {
+        let mode = TransferMode::Fast {
+            max_fee: U256::from(1234),
+        };
+        assert_eq!(mode.finality_threshold(), FinalityThreshold::Fast);
+        assert!(mode.is_fast());
+        assert!(!mode.has_hook());
+        assert_eq!(mode.max_fee(), U256::from(1234));
+        assert!(mode.hook_data().is_none());
+    }
+
+    #[test]
+    fn standard_with_hook_keeps_standard_finality() {
+        let hook = Bytes::from(vec![1, 2, 3]);
+        let mode = TransferMode::StandardWithHook {
+            hook_data: hook.clone(),
+        };
+        assert_eq!(mode.finality_threshold(), FinalityThreshold::Standard);
+        assert!(!mode.is_fast());
+        assert!(mode.has_hook());
+        assert_eq!(mode.max_fee(), U256::ZERO);
+        assert_eq!(mode.hook_data(), Some(&hook));
+    }
+
+    #[test]
+    fn fast_with_hook_combines_both() {
+        let hook = Bytes::from(vec![0xde, 0xad, 0xbe, 0xef]);
+        let mode = TransferMode::FastWithHook {
+            max_fee: U256::from(500),
+            hook_data: hook.clone(),
+        };
+        assert_eq!(mode.finality_threshold(), FinalityThreshold::Fast);
+        assert!(mode.is_fast());
+        assert!(mode.has_hook());
+        assert_eq!(mode.max_fee(), U256::from(500));
+        assert_eq!(mode.hook_data(), Some(&hook));
+    }
+}

--- a/src/bridge/v2.rs
+++ b/src/bridge/v2.rs
@@ -19,6 +19,8 @@ use tokio::time::sleep;
 use tracing::{debug, error, info, Instrument};
 use url::Url;
 
+use super::transfer_mode::TransferMode;
+
 /// Result of attempting to mint on the destination chain
 ///
 /// CCTP v2 is permissionless - anyone can relay a message once Circle's attestation
@@ -55,12 +57,12 @@ use crate::contracts::v2::{MessageTransmitterV2Contract, TokenMessengerV2Contrac
 /// # Example
 ///
 /// ```rust,no_run
-/// # use cctp_rs::CctpV2Bridge;
+/// # use cctp_rs::{CctpV2Bridge, TransferMode};
 /// # use alloy_chains::NamedChain;
 /// # use alloy_provider::ProviderBuilder;
 /// # use alloy_primitives::{Address, U256, Bytes};
 /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-/// // Standard transfer
+/// // Standard transfer (default)
 /// let provider = ProviderBuilder::new().connect("http://localhost:8545").await?;
 /// let bridge = CctpV2Bridge::builder()
 ///     .source_chain(NamedChain::Mainnet)
@@ -78,12 +80,32 @@ use crate::contracts::v2::{MessageTransmitterV2Contract, TokenMessengerV2Contrac
 ///     .source_provider(provider2.clone())
 ///     .destination_provider(provider2)
 ///     .recipient("0x742d35Cc6634C0532925a3b844Bc9e7595f8fA0d".parse()?)
-///     .fast_transfer(true)
-///     .max_fee(U256::from(100))
+///     .transfer_mode(TransferMode::FastWithHook {
+///         max_fee: U256::from(100),
+///         hook_data: Bytes::from(vec![0xde, 0xad, 0xbe, 0xef]),
+///     })
 ///     .build();
 /// # Ok(())
 /// # }
 /// ```
+///
+/// # Transfer mode selection
+///
+/// The four valid CCTP v2 configurations are expressed via [`TransferMode`]:
+///
+/// | Mode | Finality | Hook | On-chain call |
+/// |---|---|---|---|
+/// | [`Standard`](TransferMode::Standard) | 2000 (finalized) | none | `depositForBurn` |
+/// | [`Fast`](TransferMode::Fast) | 1000 (confirmed) | none | `depositForBurn` |
+/// | [`StandardWithHook`](TransferMode::StandardWithHook) | 2000 | yes | `depositForBurnWithHook` |
+/// | [`FastWithHook`](TransferMode::FastWithHook) | 1000 | yes | `depositForBurnWithHook` |
+///
+/// Earlier versions exposed `fast_transfer`, `hook_data`, and `max_fee` as
+/// independent builder fields. That shape allowed contradictory configs
+/// (e.g. fast + hook) that the bridge silently resolved to standard
+/// finality while still reporting fast — see [issue
+/// 218](https://github.com/semiotic-ai/cctp-rs/issues/218). The enum
+/// removes the precedence question by construction.
 #[derive(Builder, Clone, Debug)]
 pub struct CctpV2<P: Provider<Ethereum> + Clone> {
     source_provider: P,
@@ -92,15 +114,10 @@ pub struct CctpV2<P: Provider<Ethereum> + Clone> {
     destination_chain: NamedChain,
     recipient: Address,
 
-    /// Enable fast transfer (sub-30 second settlement)
+    /// Selects which v2 burn variant the bridge sends. Defaults to
+    /// [`TransferMode::Standard`].
     #[builder(default)]
-    fast_transfer: bool,
-
-    /// Optional hook data for programmable actions on destination chain
-    hook_data: Option<Bytes>,
-
-    /// Maximum fee willing to pay for fast transfer (in USDC atomic units)
-    max_fee: Option<U256>,
+    transfer_mode: TransferMode,
 
     /// Override the Iris API base URL. Primarily intended for pointing the
     /// bridge at a local mock server (e.g. `wiremock`) in tests, or at a
@@ -158,28 +175,38 @@ impl<P: Provider<Ethereum> + Clone> CctpV2<P> {
         &self.recipient
     }
 
-    /// Returns whether fast transfer is enabled
+    /// Returns the configured transfer mode.
+    pub fn transfer_mode(&self) -> &TransferMode {
+        &self.transfer_mode
+    }
+
+    /// Returns whether fast transfer is enabled (derived from
+    /// [`Self::transfer_mode`]).
     pub fn is_fast_transfer(&self) -> bool {
-        self.fast_transfer
+        self.transfer_mode.is_fast()
     }
 
-    /// Returns the hook data if set
+    /// Returns the hook data if the configured mode carries any.
     pub fn hook_data(&self) -> Option<&Bytes> {
-        self.hook_data.as_ref()
+        self.transfer_mode.hook_data()
     }
 
-    /// Returns the max fee if set
+    /// Returns the fast-transfer fee cap, or `None` when the mode is not a
+    /// fast variant. Standard modes implicitly use a zero `maxFee` on-chain.
     pub fn max_fee(&self) -> Option<U256> {
-        self.max_fee
+        if self.transfer_mode.is_fast() {
+            Some(self.transfer_mode.max_fee())
+        } else {
+            None
+        }
     }
 
-    /// Returns the finality threshold based on configuration
+    /// Returns the finality threshold for the configured mode.
+    ///
+    /// Always agrees with the `min_finality_threshold` the bridge will send
+    /// on-chain — both are derived from the same [`TransferMode`].
     pub fn finality_threshold(&self) -> FinalityThreshold {
-        if self.fast_transfer {
-            FinalityThreshold::Fast
-        } else {
-            FinalityThreshold::Standard
-        }
+        self.transfer_mode.finality_threshold()
     }
 
     /// Gets the `MessageSent` event data from a CCTP v2 bridge transaction
@@ -265,8 +292,8 @@ impl<P: Provider<Ethereum> + Clone> CctpV2<P> {
                     message_hash = %hex::encode(message_hash),
                     message_length_bytes = message_sent_event.len(),
                     version = "v2",
-                    fast_transfer = self.fast_transfer,
-                    has_hooks = self.hook_data.is_some(),
+                    fast_transfer = self.transfer_mode.is_fast(),
+                    has_hooks = self.transfer_mode.has_hook(),
                     event = "message_sent_event_extracted"
                 );
 
@@ -366,7 +393,7 @@ impl<P: Provider<Ethereum> + Clone> CctpV2<P> {
                 url = %url,
                 tx_hash = %tx_hash,
                 version = "v2",
-                fast_transfer = self.fast_transfer,
+                fast_transfer = self.transfer_mode.is_fast(),
                 finality_threshold = %self.finality_threshold(),
                 event = "attestation_polling_started"
             );
@@ -471,7 +498,7 @@ impl<P: Provider<Ethereum> + Clone> CctpV2<P> {
                                     message_length_bytes = message_bytes.len(),
                                     attestation_length_bytes = attestation_bytes.len(),
                                     version = "v2",
-                                    fast_transfer = self.fast_transfer,
+                                    fast_transfer = self.transfer_mode.is_fast(),
                                     event = "attestation_complete"
                                 );
                                 Ok(Some((message_bytes, attestation_bytes)))
@@ -557,36 +584,40 @@ impl<P: Provider<Ethereum> + Clone> CctpV2<P> {
         let token_messenger =
             TokenMessengerV2Contract::new(token_messenger_address, self.source_provider.clone());
 
-        let tx_request = if let Some(hook_data) = &self.hook_data {
-            // Use depositForBurnWithHook if hooks are configured
-            token_messenger.deposit_for_burn_with_hooks_transaction(
-                from,
-                self.recipient,
-                destination_domain,
-                token_address,
-                amount,
-                hook_data.clone(),
-            )
-        } else if self.fast_transfer {
-            // Use fast transfer variant
-            let max_fee = self.max_fee.unwrap_or(U256::ZERO);
-            token_messenger.deposit_for_burn_fast_transaction(
+        // Wire values come from the same `TransferMode` helpers the accessors
+        // expose, so `finality_threshold()` / `max_fee()` and the on-chain
+        // `minFinalityThreshold` / `maxFee` cannot drift apart — the structural
+        // defense behind the issue #218 fix.
+        let max_fee = self.transfer_mode.max_fee();
+        let min_finality_threshold = self.transfer_mode.finality_threshold().as_u32();
+
+        let tx_request = match self.transfer_mode.hook_data() {
+            Some(hook_data) => token_messenger.deposit_for_burn_with_hooks_transaction(
                 from,
                 self.recipient,
                 destination_domain,
                 token_address,
                 amount,
                 max_fee,
-            )
-        } else {
-            // Standard transfer
-            token_messenger.deposit_for_burn_transaction(
+                min_finality_threshold,
+                hook_data.clone(),
+            ),
+            None if self.transfer_mode.is_fast() => token_messenger
+                .deposit_for_burn_fast_transaction(
+                    from,
+                    self.recipient,
+                    destination_domain,
+                    token_address,
+                    amount,
+                    max_fee,
+                ),
+            None => token_messenger.deposit_for_burn_transaction(
                 from,
                 self.recipient,
                 destination_domain,
                 token_address,
                 amount,
-            )
+            ),
         };
 
         info!(
@@ -594,8 +625,9 @@ impl<P: Provider<Ethereum> + Clone> CctpV2<P> {
             amount = %amount,
             token_address = %token_address,
             destination_domain = %destination_domain,
-            fast_transfer = self.fast_transfer,
-            has_hooks = self.hook_data.is_some(),
+            fast_transfer = self.transfer_mode.is_fast(),
+            has_hooks = self.transfer_mode.has_hook(),
+            finality_threshold = %self.transfer_mode.finality_threshold(),
             version = "v2",
             event = "burn_transaction_initiated"
         );
@@ -785,7 +817,7 @@ impl<P: Provider<Ethereum> + Clone> CctpV2<P> {
 
         let max_attempts = max_attempts.unwrap_or(60);
         let poll_interval = poll_interval.unwrap_or_else(|| {
-            if self.fast_transfer {
+            if self.transfer_mode.is_fast() {
                 self.destination_chain
                     .fast_transfer_confirmation_time_seconds()
                     .unwrap_or(5)
@@ -799,7 +831,7 @@ impl<P: Provider<Ethereum> + Clone> CctpV2<P> {
         info!(
             max_attempts = max_attempts,
             poll_interval_secs = poll_interval,
-            fast_transfer = self.fast_transfer,
+            fast_transfer = self.transfer_mode.is_fast(),
             version = "v2",
             event = "wait_for_receive_started"
         );
@@ -1129,8 +1161,8 @@ impl<P: Provider<Ethereum> + Clone> CctpV2<P> {
             token_address = %token_address,
             source_chain = ?self.source_chain,
             destination_chain = ?self.destination_chain,
-            fast_transfer = self.fast_transfer,
-            has_hooks = self.hook_data.is_some(),
+            fast_transfer = self.transfer_mode.is_fast(),
+            has_hooks = self.transfer_mode.has_hook(),
             version = "v2",
             event = "full_transfer_initiated"
         );
@@ -1147,7 +1179,7 @@ impl<P: Provider<Ethereum> + Clone> CctpV2<P> {
         // Note: The MessageSent event log contains zeros in the nonce field.
         // Circle fills in the actual nonce before signing, so we must use the message
         // returned by get_attestation (from Circle's API), not from the event log.
-        let polling_config = if self.fast_transfer {
+        let polling_config = if self.transfer_mode.is_fast() {
             PollingConfig::fast_transfer()
         } else {
             PollingConfig::default()
@@ -1254,11 +1286,11 @@ impl<P: Provider<Ethereum> + Clone> CctpBridge for CctpV2<P> {
     }
 
     fn supports_fast_transfer(&self) -> bool {
-        self.fast_transfer
+        self.transfer_mode.is_fast()
     }
 
     fn supports_hooks(&self) -> bool {
-        self.hook_data.is_some()
+        self.transfer_mode.has_hook()
     }
 
     fn finality_threshold(&self) -> Option<FinalityThreshold> {
@@ -1365,7 +1397,9 @@ mod tests {
             .source_provider(provider.clone())
             .destination_provider(provider)
             .recipient(Address::ZERO)
-            .fast_transfer(true)
+            .transfer_mode(TransferMode::Fast {
+                max_fee: U256::ZERO,
+            })
             .build();
 
         assert!(fast.is_fast_transfer());
@@ -1398,7 +1432,9 @@ mod tests {
             .source_provider(provider.clone())
             .destination_provider(provider)
             .recipient(Address::ZERO)
-            .hook_data(hook_data.clone())
+            .transfer_mode(TransferMode::StandardWithHook {
+                hook_data: hook_data.clone(),
+            })
             .build();
 
         assert!(with_hooks.supports_hooks());
@@ -1417,8 +1453,7 @@ mod tests {
             .source_provider(provider.clone())
             .destination_provider(provider)
             .recipient(Address::ZERO)
-            .fast_transfer(true)
-            .max_fee(max_fee)
+            .transfer_mode(TransferMode::Fast { max_fee })
             .build();
 
         assert_eq!(bridge.max_fee(), Some(max_fee));
@@ -1456,9 +1491,10 @@ mod tests {
             .source_provider(provider.clone())
             .destination_provider(provider)
             .recipient(Address::ZERO)
-            .fast_transfer(true)
-            .max_fee(U256::from(500))
-            .hook_data(Bytes::from(vec![1, 2, 3]))
+            .transfer_mode(TransferMode::FastWithHook {
+                max_fee: U256::from(500),
+                hook_data: Bytes::from(vec![1, 2, 3]),
+            })
             .build();
 
         assert_eq!(bridge.source_chain(), &NamedChain::Mainnet);
@@ -1504,8 +1540,9 @@ mod tests {
             .source_provider(provider.clone())
             .destination_provider(provider)
             .recipient(Address::ZERO)
-            .fast_transfer(true)
-            .max_fee(U256::from(1000))
+            .transfer_mode(TransferMode::Fast {
+                max_fee: U256::from(1000),
+            })
             .build();
 
         // Verify configuration for fast transfer
@@ -1529,7 +1566,9 @@ mod tests {
             .source_provider(provider.clone())
             .destination_provider(provider)
             .recipient(Address::ZERO)
-            .hook_data(hook_data.clone())
+            .transfer_mode(TransferMode::StandardWithHook {
+                hook_data: hook_data.clone(),
+            })
             .build();
 
         // Verify configuration for hooks transfer
@@ -1539,27 +1578,34 @@ mod tests {
     }
 
     #[test]
-    fn test_v2_contract_method_selection_priority() {
+    fn test_v2_fast_with_hook_uses_fast_finality_and_fee() {
         let provider =
             ProviderBuilder::new().connect_http("http://localhost:8545".parse().unwrap());
         let hook_data = Bytes::from(vec![1, 2, 3, 4]);
 
-        // Hooks should take priority over fast transfer
+        // FastWithHook combines fast finality with hook data and a fee cap.
+        // Previously the bridge silently fell back to standard finality with
+        // zero fee while still reporting fast — see issue #218.
         let bridge = CctpV2::builder()
             .source_chain(NamedChain::Mainnet)
             .destination_chain(NamedChain::Linea)
             .source_provider(provider.clone())
             .destination_provider(provider)
             .recipient(Address::ZERO)
-            .fast_transfer(true)
-            .max_fee(U256::from(1000))
-            .hook_data(hook_data.clone())
+            .transfer_mode(TransferMode::FastWithHook {
+                max_fee: U256::from(1000),
+                hook_data: hook_data.clone(),
+            })
             .build();
 
-        // Verify hooks take priority
         assert!(bridge.is_fast_transfer());
         assert_eq!(bridge.hook_data(), Some(&hook_data));
         assert_eq!(bridge.finality_threshold(), FinalityThreshold::Fast);
+        assert_eq!(bridge.max_fee(), Some(U256::from(1000)));
+        assert!(matches!(
+            bridge.transfer_mode(),
+            TransferMode::FastWithHook { .. }
+        ));
     }
 
     #[rstest]
@@ -1581,7 +1627,9 @@ mod tests {
             .source_provider(provider.clone())
             .destination_provider(provider)
             .recipient(Address::ZERO)
-            .fast_transfer(true)
+            .transfer_mode(TransferMode::Fast {
+                max_fee: U256::ZERO,
+            })
             .build();
 
         assert!(bridge.supports_fast_transfer());
@@ -1704,7 +1752,9 @@ mod tests {
             .source_provider(provider.clone())
             .destination_provider(provider)
             .recipient(Address::ZERO)
-            .fast_transfer(true)
+            .transfer_mode(TransferMode::Fast {
+                max_fee: U256::ZERO,
+            })
             .build();
 
         assert_eq!(fast.finality_threshold(), FinalityThreshold::Fast);
@@ -1797,17 +1847,30 @@ mod tests {
         let provider =
             ProviderBuilder::new().connect_http("http://localhost:8545".parse().unwrap());
 
-        // Without max_fee specified
-        let no_fee = CctpV2::builder()
+        // Fast with zero max_fee — still reports Some(ZERO) because the mode is fast.
+        // Standard modes report None.
+        let zero_fee = CctpV2::builder()
             .source_chain(NamedChain::Mainnet)
             .destination_chain(NamedChain::Linea)
             .source_provider(provider.clone())
             .destination_provider(provider.clone())
             .recipient(Address::ZERO)
-            .fast_transfer(true)
+            .transfer_mode(TransferMode::Fast {
+                max_fee: U256::ZERO,
+            })
             .build();
 
-        assert_eq!(no_fee.max_fee(), None);
+        assert_eq!(zero_fee.max_fee(), Some(U256::ZERO));
+
+        // Standard modes have no fee
+        let standard = CctpV2::builder()
+            .source_chain(NamedChain::Mainnet)
+            .destination_chain(NamedChain::Linea)
+            .source_provider(provider.clone())
+            .destination_provider(provider.clone())
+            .recipient(Address::ZERO)
+            .build();
+        assert_eq!(standard.max_fee(), None);
 
         // With max_fee specified
         let with_fee = CctpV2::builder()
@@ -1816,8 +1879,9 @@ mod tests {
             .source_provider(provider.clone())
             .destination_provider(provider)
             .recipient(Address::ZERO)
-            .fast_transfer(true)
-            .max_fee(U256::from(500))
+            .transfer_mode(TransferMode::Fast {
+                max_fee: U256::from(500),
+            })
             .build();
 
         assert_eq!(with_fee.max_fee(), Some(U256::from(500)));
@@ -1835,7 +1899,9 @@ mod tests {
             .source_provider(provider.clone())
             .destination_provider(provider)
             .recipient(Address::ZERO)
-            .hook_data(hook_data.clone())
+            .transfer_mode(TransferMode::StandardWithHook {
+                hook_data: hook_data.clone(),
+            })
             .build();
 
         assert_eq!(bridge.hook_data(), Some(&hook_data));

--- a/src/contracts/v2/token_messenger_v2.rs
+++ b/src/contracts/v2/token_messenger_v2.rs
@@ -179,7 +179,7 @@ impl<P: Provider<Ethereum>> TokenMessengerV2Contract<P> {
         )
     }
 
-    /// Create transaction for depositForBurn with hooks
+    /// Create transaction for `depositForBurnWithHook`
     ///
     /// # Arguments
     ///
@@ -188,13 +188,19 @@ impl<P: Provider<Ethereum>> TokenMessengerV2Contract<P> {
     /// * `destination_domain` - CCTP domain ID for destination chain
     /// * `token_address` - USDC token contract address
     /// * `amount` - Amount to transfer
-    /// * `hook_data` - Arbitrary bytes to pass to destination chain for programmable actions
+    /// * `max_fee` - Maximum fee willing to pay. Use `U256::ZERO` for standard
+    ///   finality; supply a non-zero cap when pairing hooks with fast finality.
+    /// * `min_finality_threshold` - 1000 (fast) or 2000 (standard). Hooks are
+    ///   supported at both thresholds at the protocol level — pass whichever
+    ///   matches the intended transfer mode.
+    /// * `hook_data` - Arbitrary bytes to pass to destination chain for
+    ///   programmable actions
     ///
     /// # Hooks
     ///
     /// Hook data is opaque to CCTP but can be used by integrators to trigger
     /// actions on the destination chain (e.g., swap, lend, stake).
-    #[allow(dead_code)]
+    #[allow(clippy::too_many_arguments)]
     pub fn deposit_for_burn_with_hooks_transaction(
         &self,
         from_address: Address,
@@ -202,6 +208,8 @@ impl<P: Provider<Ethereum>> TokenMessengerV2Contract<P> {
         destination_domain: DomainId,
         token_address: Address,
         amount: U256,
+        max_fee: U256,
+        min_finality_threshold: u32,
         hook_data: Bytes,
     ) -> TransactionRequest {
         info!(
@@ -210,11 +218,12 @@ impl<P: Provider<Ethereum>> TokenMessengerV2Contract<P> {
             destination_domain = %destination_domain,
             token_address = %token_address,
             amount = %amount,
+            max_fee = %max_fee,
             hook_data_len = hook_data.len(),
             contract_address = %self.instance.address(),
             version = "v2",
             has_hooks = true,
-            finality_threshold = 2000,
+            finality_threshold = min_finality_threshold,
             event = "deposit_for_burn_hooks_transaction_created"
         );
 
@@ -225,8 +234,8 @@ impl<P: Provider<Ethereum>> TokenMessengerV2Contract<P> {
                 recipient.into_word(),
                 token_address,
                 Address::ZERO.into_word(), // destination_caller: 0x0 = anyone
-                U256::ZERO,                // max_fee: 0 for standard transfers
-                2000,                      // min_finality_threshold: 2000 = finalized
+                max_fee,
+                min_finality_threshold,
                 hook_data,
             )
             .from(from_address)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,9 +26,9 @@
 //! ## Quick Start (V2, recommended)
 //!
 //! ```rust,no_run
-//! use cctp_rs::{CctpV2Bridge, CctpError, PollingConfig};
+//! use cctp_rs::{CctpV2Bridge, CctpError, PollingConfig, TransferMode};
 //! use alloy_chains::NamedChain;
-//! use alloy_primitives::FixedBytes;
+//! use alloy_primitives::{FixedBytes, U256};
 //!
 //! # async fn example() -> Result<(), CctpError> {
 //! # use alloy_provider::ProviderBuilder;
@@ -42,7 +42,7 @@
 //!     .source_provider(eth_provider)
 //!     .destination_provider(linea_provider)
 //!     .recipient("0x742d35Cc6634C0532925a3b844Bc9e7595f8fA0d".parse()?)
-//!     .fast_transfer(true)  // Enable sub-30 second settlement
+//!     .transfer_mode(TransferMode::Fast { max_fee: U256::from(100) })  // sub-30 second settlement
 //!     .build();
 //!
 //! // V2 uses transaction hash directly and returns both message and attestation
@@ -118,6 +118,7 @@
 //! - [`Cctp`] and [`CctpV2Bridge`] - Core CCTP bridge implementations for v1 and v2
 //! - [`CctpV1`] and [`CctpV2`] - Traits for chain-specific configurations
 //! - [`PollingConfig`] - Configuration for attestation polling behavior
+//! - [`TransferMode`] - Selects which v2 burn variant (standard / fast / with hook) the bridge sends
 //! - [`ParsedV2Message`] and [`ParsedV2MessageSummary`] - Parse canonical v2 messages into serializable structs
 //! - [`ParseMessageError`] - Error type for canonical v2 message parsing
 //! - [`InvalidDomainId`] and [`InvalidFinalityThreshold`] - Errors returned by `TryFrom<u32>` for [`DomainId`] / [`FinalityThreshold`]
@@ -152,7 +153,7 @@ mod provider;
 // Public API - minimal surface for 1.0.0 stability
 pub use bridge::{
     batch_token_state, Cctp, CctpBridge, CctpV2 as CctpV2Bridge, MintResult, PollingConfig,
-    TokenState,
+    TokenState, TransferMode,
 };
 pub use chain::addresses::{
     CCTP_V2_MESSAGE_TRANSMITTER_MAINNET, CCTP_V2_MESSAGE_TRANSMITTER_TESTNET,


### PR DESCRIPTION
## Summary

Replace the three independent `fast_transfer` / `hook_data` / `max_fee`
builder fields on `CctpV2Bridge` with a single `transfer_mode:
TransferMode` enum covering the four valid CCTP v2 burn configurations.
The previous shape allowed callers to combine `fast_transfer=true` with
`hook_data=Some(...)`, which silently routed to the standard-finality
hook contract path while `finality_threshold()` continued to report
`Fast` — operators saw fast attestation reported but observed standard
settlement latency. `FastWithHook` now reaches Circle's
`depositForBurnWithHook` with `minFinalityThreshold=1000` and the
caller-supplied `maxFee`, which the on-chain contract supports natively.

Closes #218.

## What's in the diff

- `src/bridge/transfer_mode.rs` (new): `TransferMode` enum with four
  variants (`Standard`, `Fast { max_fee }`, `StandardWithHook {
  hook_data }`, `FastWithHook { max_fee, hook_data }`). Marked
  `#[non_exhaustive]` so future protocol additions don't force a major
  SemVer bump for downstream match statements.
- `src/bridge/v2.rs`: `CctpV2` struct now holds a single
  `transfer_mode` field. `burn()` derives both the on-chain
  `min_finality_threshold` / `max_fee` and the public
  `finality_threshold()` / `max_fee()` accessors from the same
  `TransferMode` helpers, so the accessor and the wire cannot drift
  apart by construction (the structural defense behind the issue #218
  fix).
- `src/contracts/v2/token_messenger_v2.rs`:
  `deposit_for_burn_with_hooks_transaction` now takes `max_fee: U256`
  and `min_finality_threshold: u32` arguments instead of hardcoding
  standard finality with zero fee. The contract ABI already supports
  the parameter pair; only the Rust wrapper was limiting it.
- `src/bridge/mod.rs`, `src/lib.rs`: re-export `TransferMode`.
- Examples and CHANGELOG migrated to the new builder API.

## Acceptance check (from #218)

- [x] **Confirm intended Circle semantics for hooks + fast transfer.**
  Both `depositForBurn` and `depositForBurnWithHook` in the v2 ABI
  accept `maxFee` and `minFinalityThreshold` (confirmed by the JSON
  ABI in `abis/v2/token_messenger_v2.json` and Circle's developer
  reference at <https://developers.circle.com/cctp/evm-smart-contracts>);
  hooks + fast is supported at the protocol level.
- [x] **If incompatible, reject at construction.** N/A — Circle
  supports the combination, so we route it correctly instead.
- [x] **If compatible, express transfer mode as an enum instead of
  independent booleans.** Done via `TransferMode`.
- [x] **Add tests and docs that state the intended precedence and
  finality behavior.** New `test_v2_fast_with_hook_uses_fast_finality_and_fee`
  in `src/bridge/v2.rs` and the four-quadrant validator in
  `examples/v2_integration_validation.rs` cover all four mode
  combinations; the \`TransferMode\` doctest in
  \`src/bridge/transfer_mode.rs\` and the bridge-level \`TransferMode
  selection\` table in the \`CctpV2\` docstring document the wire shape.

## Migration

Old:
\`\`\`rust
let bridge = CctpV2Bridge::builder()
    .source_chain(NamedChain::Mainnet)
    .destination_chain(NamedChain::Linea)
    .source_provider(p1)
    .destination_provider(p2)
    .recipient(addr)
    .fast_transfer(true)
    .max_fee(U256::from(100))
    .hook_data(hook)
    .build();
\`\`\`

New:
\`\`\`rust
let bridge = CctpV2Bridge::builder()
    .source_chain(NamedChain::Mainnet)
    .destination_chain(NamedChain::Linea)
    .source_provider(p1)
    .destination_provider(p2)
    .recipient(addr)
    .transfer_mode(TransferMode::FastWithHook { max_fee: U256::from(100), hook_data: hook })
    .build();
\`\`\`

The \`max_fee()\` accessor now returns \`Some(U256::ZERO)\` (not \`None\`)
for fast variants explicitly constructed with a zero fee — the prior
shape returned \`None\` when the optional \`.max_fee(...)\` builder
method was unset alongside \`.fast_transfer(true)\`. Callers that used
the \`Option\` to detect 'fee explicitly set' should switch to inspecting
\`transfer_mode()\` directly.

## Test plan

- [x] \`cargo nextest run --all-features\` — 207/207 pass
- [x] \`cargo test --doc --all-features\` — 28/28 pass (19 ignored)
- [x] \`cargo clippy --workspace --all-targets --all-features -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean
- [x] \`cargo run --example v2_integration_validation\` exercises all
  four modes (note: this example also has a pre-existing assertion
  failure on \`/v2/attestations/\` path at line 404 that reproduces on
  \`main\` — out of scope here, will file as a follow-up)
- [ ] Live testnet burn against Iris sandbox — deferred to manual
  validation after merge

## Self-review notes

A pre-commit \`/code-review\` pass surfaced several findings; the
high-priority ones (burn() hardcoding \`FinalityThreshold::Standard.as_u32()\`,
missing \`#[non_exhaustive]\`, stale \`#[allow(dead_code)]\` on the now-used
hooks helper, undocumented \`max_fee()\` Some/None flip) were resolved
in-place. The skipped findings — typing the wrapper's
\`min_finality_threshold: u32\` as \`FinalityThreshold\`, and unifying
\`TransferMode::max_fee()\`'s \`U256::ZERO\` for Standard with the bridge
accessor's \`None\` — are design questions worth a separate discussion,
not blockers for this PR.