### PR TITLE
fix: align v2 integration validation example with the v2 messages URL

### DIFF
--- a/examples/v2_integration_validation.rs
+++ b/examples/v2_integration_validation.rs
@@ -397,24 +397,24 @@ fn validate_api_endpoints() -> Result<(), Box<dyn std::error::Error>> {
         mainnet_api.as_str().trim_end_matches('/')
     );
 
-    // Test URL construction with message hash
+    // Test URL construction with transaction hash
     let test_hash = [0xab; 32];
     let url = mainnet_bridge.create_url(test_hash.into())?;
 
     assert!(
-        url.as_str().contains("/v2/attestations/"),
-        "Should use v2 path"
+        url.as_str().contains("/v2/messages/"),
+        "Should use v2 messages path"
     );
     assert!(
-        url.as_str().contains("0xabab"),
-        "Should include hash with 0x prefix"
+        url.as_str().contains("transactionHash=0xabab"),
+        "Should include transaction hash query param with 0x prefix"
     );
     assert!(url
         .as_str()
-        .starts_with("https://iris-api.circle.com/v2/attestations/0x"));
+        .starts_with("https://iris-api.circle.com/v2/messages/"));
 
     println!("   ✓ Full URL format: {url}");
-    println!("   ✓ Path: /v2/attestations/");
+    println!("   ✓ Path: /v2/messages/{{domain}}?transactionHash=…");
     println!("   ✓ Hash format: 0x-prefixed\n");
 
     // Test testnet API
@@ -440,7 +440,16 @@ fn validate_api_endpoints() -> Result<(), Box<dyn std::error::Error>> {
     );
 
     let testnet_url = testnet_bridge.create_url(test_hash.into())?;
-    assert!(testnet_url.as_str().contains("iris-api-sandbox"));
+    assert!(
+        testnet_url
+            .as_str()
+            .starts_with("https://iris-api-sandbox.circle.com/v2/messages/"),
+        "Testnet should use sandbox v2 messages path"
+    );
+    assert!(
+        testnet_url.as_str().contains("transactionHash=0xabab"),
+        "Should include transaction hash query param with 0x prefix"
+    );
     println!("   ✓ Uses sandbox environment");
     println!("   ✓ Full URL format: {testnet_url}\n");
 


### PR DESCRIPTION
## Summary

`cargo run --example v2_integration_validation` was panicking at the API endpoint construction check because the assertion was still pinned to `/v2/attestations/` — the v1 URL shape. The v2 path emits `/v2/messages/{domain}?transactionHash=…`. Closes #226.

This unblocks anyone copy-pasting the example from a recent PR test plan and restores its role as living documentation of the v2 API.

## What's in the diff

- `examples/v2_integration_validation.rs` (mainnet block) — replace the
  `/v2/attestations/` assertions and operator-facing path summary with
  the actual v2 messages-path shape; strengthen the hash assertion to
  require the `transactionHash=` query-param prefix.
- `examples/v2_integration_validation.rs` (testnet block) — tighten
  parity assertions so the same regression cannot slip through against
  the sandbox URL.

## Acceptance check (from #226)

- [x] Mainnet assertions and prints match the v2 messages URL shape
- [x] Testnet block fixed in parallel
- [x] `cargo run --example v2_integration_validation` completes end-to-end with `✅ All validations passed!`
- Skipped: the optional `insta` snapshot suggestion. The in-tree v2 snapshot tests in `src/bridge/v2.rs` (`test_v2_messages_url_format_*`) already pin the full URL — duplicating that in the example would shift it from "living documentation" toward a second snapshot harness for the same invariant.

## Test plan

- [x] `cargo run --example v2_integration_validation` — completes, `✅ All validations passed!`
- [x] `cargo nextest run --workspace --all-features` — 207/207 pass
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt --check` — clean