### PR TITLE
test: pin v2 fast-with-hook wire shape against issue #218

### DIFF
--- a/src/bridge/v2.rs
+++ b/src/bridge/v2.rs
@@ -1608,6 +1608,76 @@ mod tests {
         ));
     }
 
+    #[test]
+    fn test_v2_fast_with_hook_calldata_carries_fast_finality_and_max_fee() {
+        use crate::contracts::v2::TokenMessengerV2;
+        use alloy_sol_types::SolCall;
+
+        let provider =
+            ProviderBuilder::new().connect_http("http://localhost:8545".parse().unwrap());
+        let hook_data = Bytes::from(vec![0xde, 0xad]);
+        let max_fee = U256::from(1000);
+
+        // Issue #218 was an accessor-vs-wire divergence: the bridge reported fast
+        // finality while the on-chain call carried standard finality and zero fee.
+        // Pin the fix to the wire by decoding the calldata the bridge would send
+        // and asserting `minFinalityThreshold` and `maxFee` directly.
+        let bridge = CctpV2::builder()
+            .source_chain(NamedChain::Mainnet)
+            .destination_chain(NamedChain::Linea)
+            .source_provider(provider.clone())
+            .destination_provider(provider.clone())
+            .recipient(Address::ZERO)
+            .transfer_mode(TransferMode::FastWithHook {
+                max_fee,
+                hook_data: hook_data.clone(),
+            })
+            .build();
+
+        let from = Address::repeat_byte(0xaa);
+        let token_address = Address::repeat_byte(0xbb);
+        let amount = U256::from(1_000_000_u64);
+        let destination_domain = bridge.destination_domain_id().unwrap();
+        let token_messenger_address = bridge.source_chain().token_messenger_v2_address().unwrap();
+        let token_messenger = TokenMessengerV2Contract::new(token_messenger_address, provider);
+
+        // Pull wire values from `bridge.transfer_mode()` — the same source `burn()`
+        // uses (`src/bridge/v2.rs:591-592`). A future refactor that drops either
+        // accessor must break this test before it can ship a wrong wire shape.
+        let mode = bridge.transfer_mode();
+        let mode_max_fee = mode.max_fee();
+        let mode_finality_threshold = mode.finality_threshold().as_u32();
+        let mode_hook_data = mode
+            .hook_data()
+            .expect("FastWithHook carries hook data")
+            .clone();
+
+        let tx_request = token_messenger.deposit_for_burn_with_hooks_transaction(
+            from,
+            *bridge.recipient(),
+            destination_domain,
+            token_address,
+            amount,
+            mode_max_fee,
+            mode_finality_threshold,
+            mode_hook_data,
+        );
+
+        let calldata = tx_request
+            .input
+            .input()
+            .expect("transaction request carries calldata");
+
+        let decoded = TokenMessengerV2::depositForBurnWithHookCall::abi_decode(calldata)
+            .expect("calldata decodes as depositForBurnWithHook");
+
+        assert_eq!(decoded.minFinalityThreshold, 1000);
+        assert_eq!(decoded.maxFee, max_fee);
+        assert_eq!(decoded.amount, amount);
+        assert_eq!(decoded.destinationDomain, destination_domain.as_u32());
+        assert_eq!(decoded.hookData, hook_data);
+    }
+
     #[rstest]
     #[case(NamedChain::Mainnet, NamedChain::Linea)]
     #[case(NamedChain::Arbitrum, NamedChain::Sonic)]


### PR DESCRIPTION
## Summary

Issue #218 was an accessor-vs-wire divergence in `CctpV2::burn`: the
bridge reported fast finality while the on-chain calldata carried
standard finality and zero fee for `TransferMode::FastWithHook`. PR
#222 fixed it and added the accessor-only test
`test_v2_fast_with_hook_uses_fast_finality_and_fee`, but that test
cannot catch a future regression of the same shape — by construction,
it only inspects what the bridge *reports*, not what it would *send*.

This PR adds the smallest test that pins the wire shape: build a
`CctpV2` with `FastWithHook`, pull `max_fee` / `min_finality_threshold`
/ `hook_data` from `bridge.transfer_mode()` (the same source `burn()`
uses at `src/bridge/v2.rs:591-592`), call
`deposit_for_burn_with_hooks_transaction` with those values, decode the
resulting calldata via `TokenMessengerV2::depositForBurnWithHookCall::abi_decode`,
and assert `minFinalityThreshold == 1000` and `maxFee == U256::from(1000)`.

Closes #225.

## What's in the diff

- `src/bridge/v2.rs` — new test `test_v2_fast_with_hook_calldata_carries_fast_finality_and_max_fee`, placed directly after the existing accessor test it complements.

## Acceptance check (from #225)

- [x] Builds a `CctpV2Bridge` with `TransferMode::FastWithHook { max_fee: U256::from(1000), hook_data: Bytes::from(vec![0xde, 0xad]) }`.
- [x] Calls `deposit_for_burn_with_hooks_transaction` directly with values pulled from `bridge.transfer_mode()` — the same path `burn()` takes.
- [x] Decodes `tx_request.input.input()` via the sol!-generated `TokenMessengerV2::depositForBurnWithHookCall::abi_decode(..)` and asserts `minFinalityThreshold == 1000` and `maxFee == U256::from(1000)`.

## Mutation-test sanity check

Verified the test catches the issue #218 failure mode: mutating
`src/contracts/v2/token_messenger_v2.rs:237-238` to hardcode
`U256::ZERO` and `2000` causes this test to fail with
`left: 2000, right: 1000`, while the existing accessor-only test still
passes. Reverted before commit.

## Self-review notes

One `/code-review` finding skipped with justification:

- Suggestion: replace `assert_eq!(decoded.minFinalityThreshold, 1000)` with `assert_eq!(decoded.minFinalityThreshold, mode_finality_threshold)`. **Skipped.** The literal `1000` pins the CCTP v2 protocol-level definition of fast finality. Asserting against the accessor's own output would let a regression in `FinalityThreshold::Fast::as_u32()` pass silently, weakening the test. Issue #225's "Suggested direction" also explicitly calls for the literal.

## Test plan

- [x] `cargo nextest run --workspace --all-features` — 208/208 pass (including the new test)
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt` — clean
- [x] Mutation sanity check (described above) — new test fails on a regression, accessor test does not