### PR TITLE
refactor: derive every v2 burn finality threshold from transfer_mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   arguments. The previous signature hardcoded standard finality with
   zero fee, which excluded the hook + fast-finality burn that
   Circle's `depositForBurnWithHook` supports natively.
+- **Breaking:** `TokenMessengerV2Contract::deposit_for_burn_transaction`
+  and `deposit_for_burn_fast_transaction` now take an additional
+  `min_finality_threshold: u32` argument. The previous signatures
+  hardcoded `2000` and `1000` internally, so the bridge could only
+  guarantee the wire `minFinalityThreshold` matched
+  `transfer_mode().finality_threshold()` by routing each
+  `TransferMode` to the right helper. Parameterizing both lets
+  `CctpV2::burn` derive every wire value from a single
+  `self.transfer_mode.finality_threshold().as_u32()` call and
+  extends the issue #218 structural defense to all four
+  `TransferMode` variants. Tracks issue #224.
 
 ### Fixed
 

--- a/src/bridge/v2.rs
+++ b/src/bridge/v2.rs
@@ -610,6 +610,7 @@ impl<P: Provider<Ethereum> + Clone> CctpV2<P> {
                     token_address,
                     amount,
                     max_fee,
+                    min_finality_threshold,
                 ),
             None => token_messenger.deposit_for_burn_transaction(
                 from,
@@ -617,6 +618,7 @@ impl<P: Provider<Ethereum> + Clone> CctpV2<P> {
                 destination_domain,
                 token_address,
                 amount,
+                min_finality_threshold,
             ),
         };
 

--- a/src/contracts/v2/token_messenger_v2.rs
+++ b/src/contracts/v2/token_messenger_v2.rs
@@ -84,7 +84,10 @@ impl<P: Provider<Ethereum>> TokenMessengerV2Contract<P> {
 
     /// Create the transaction request for the `depositForBurn` function (v2 standard)
     ///
-    /// Standard transfer with 2000 (finalized) threshold and no fees.
+    /// For standard (no-hook, no-fast-fee) transfers. Pass
+    /// `FinalityThreshold::Standard.as_u32()` (2000) for this path; the
+    /// parameter is exposed rather than hardcoded so the same value can be
+    /// derived from a single caller-side source of truth.
     #[allow(dead_code)]
     pub fn deposit_for_burn_transaction(
         &self,
@@ -93,6 +96,7 @@ impl<P: Provider<Ethereum>> TokenMessengerV2Contract<P> {
         destination_domain: DomainId,
         token_address: Address,
         amount: U256,
+        min_finality_threshold: u32,
     ) -> TransactionRequest {
         let span = spans::deposit_for_burn(
             &from_address,
@@ -111,7 +115,7 @@ impl<P: Provider<Ethereum>> TokenMessengerV2Contract<P> {
             amount = %amount,
             contract_address = %self.instance.address(),
             version = "v2",
-            finality_threshold = 2000,
+            finality_threshold = min_finality_threshold,
             event = "deposit_for_burn_v2_transaction_created"
         );
 
@@ -121,8 +125,8 @@ impl<P: Provider<Ethereum>> TokenMessengerV2Contract<P> {
             destination_domain,
             token_address,
             amount,
-            U256::ZERO,    // max_fee: 0 for standard transfers
-            2000,          // min_finality_threshold: 2000 = finalized
+            U256::ZERO, // max_fee: 0 for standard transfers
+            min_finality_threshold,
             Address::ZERO, // destination_caller: 0x0 = anyone
         )
     }
@@ -137,13 +141,17 @@ impl<P: Provider<Ethereum>> TokenMessengerV2Contract<P> {
     /// * `token_address` - USDC token contract address
     /// * `amount` - Amount to transfer
     /// * `max_fee` - Maximum fee willing to pay for fast transfer
+    /// * `min_finality_threshold` - Pass `FinalityThreshold::Fast.as_u32()`
+    ///   (1000) for this path. Exposed alongside `max_fee` so both wire values
+    ///   can be derived from a single caller-side source of truth.
     ///
     /// # Fast Transfer
     ///
     /// When `max_fee` >= minimum fast transfer fee for the chain, the transfer
     /// will be attested at the "confirmed" finality level (~30 seconds) instead
-    /// of "finalized" level (~15 minutes). Uses finality threshold 1000.
+    /// of "finalized" level (~15 minutes).
     #[allow(dead_code)]
+    #[allow(clippy::too_many_arguments)]
     pub fn deposit_for_burn_fast_transaction(
         &self,
         from_address: Address,
@@ -152,6 +160,7 @@ impl<P: Provider<Ethereum>> TokenMessengerV2Contract<P> {
         token_address: Address,
         amount: U256,
         max_fee: U256,
+        min_finality_threshold: u32,
     ) -> TransactionRequest {
         info!(
             from_address = %from_address,
@@ -163,7 +172,7 @@ impl<P: Provider<Ethereum>> TokenMessengerV2Contract<P> {
             contract_address = %self.instance.address(),
             version = "v2",
             transfer_type = "fast",
-            finality_threshold = 1000,
+            finality_threshold = min_finality_threshold,
             event = "deposit_for_burn_fast_transaction_created"
         );
 
@@ -173,8 +182,8 @@ impl<P: Provider<Ethereum>> TokenMessengerV2Contract<P> {
             destination_domain,
             token_address,
             amount,
-            max_fee,       // max_fee: provided by caller
-            1000,          // min_finality_threshold: 1000 = confirmed (fast)
+            max_fee,
+            min_finality_threshold,
             Address::ZERO, // destination_caller: 0x0 = anyone
         )
     }


### PR DESCRIPTION
## Summary

Extends the structural defense behind the issue #218 fix to every CCTP v2
burn arm. Before this PR the hook helper accepted
`min_finality_threshold: u32`, but the two non-hook helpers
(`deposit_for_burn_transaction`, `deposit_for_burn_fast_transaction`)
hardcoded `2000` and `1000` internally. `CctpV2::burn` picked one of those
two helpers based on `self.transfer_mode`, so the on-chain
`minFinalityThreshold` was determined by which helper was called rather
than by reading from `self.transfer_mode.finality_threshold()`. Any
future rewiring that misroutes a variant could silently emit the wrong
wire value while the accessor kept reporting the intended one — the
exact failure shape of issue #218, on the non-hook path.

After this PR, every `min_finality_threshold` value that reaches the
contract call site comes from
`self.transfer_mode.finality_threshold().as_u32()` and nowhere else.

Closes #224.

## What's in the diff

- `src/contracts/v2/token_messenger_v2.rs` — `deposit_for_burn_transaction`
  and `deposit_for_burn_fast_transaction` now take an explicit
  `min_finality_threshold: u32`; the hardcoded `2000` / `1000` literals
  are gone. Tracing fields and doc comments updated accordingly.
- `src/bridge/v2.rs` — `CctpV2::burn` passes
  `self.transfer_mode.finality_threshold().as_u32()` to every non-hook
  arm (matching the hook arm, which already worked this way after #222).
- `CHANGELOG.md` — extends the existing `[Unreleased]` breaking-change
  entry to cover the two newly-parameterized helpers.

This is a **breaking change** to two public methods on
`TokenMessengerV2Contract`; the breaking entry already in
`[Unreleased]` from #222 has been extended.

## Acceptance check (from #224)

- [x] `deposit_for_burn_transaction` parameterized with
  `min_finality_threshold: u32`, hardcoded `2000` removed.
- [x] `deposit_for_burn_fast_transaction` parameterized with
  `min_finality_threshold: u32`, hardcoded `1000` removed.
- [x] `CctpV2::burn` passes
  `self.transfer_mode.finality_threshold().as_u32()` to every arm —
  the value reaches each contract call site from exactly one source
  of truth.
- [x] The existing `burn_dispatch_wire` test module continues to pin
  the wire shape for all four `TransferMode` variants end-to-end
  (`burn_emits_expected_calldata` cases: standard, fast,
  standard_with_hook, fast_with_hook).

Implementation chose option 1 from the issue ("parameterize the two
non-hook helpers") over option 2 (expose `deposit_for_burn_internal` as
`pub(crate)` and call it directly from `burn()`). Option 1 deletes the
hardcoded constants outright — nothing left in the wrapper to drift —
while keeping the public API parallel to the hook helper.

## Test plan

- [x] `cargo nextest run -p cctp-rs --lib --bins --all-features` —
  203/203 pass, including the four `burn_dispatch_wire` cases that
  decode the calldata and assert the expected `minFinalityThreshold`
  per variant.
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean.
- [x] `cargo fmt --check` clean.
- [x] `cargo test --doc --all-features` — 28 doctests pass.