### PR TITLE
refactor: catch new TransferMode variants at compile time in CctpV2::burn

### DIFF
--- a/src/bridge/v2.rs
+++ b/src/bridge/v2.rs
@@ -591,8 +591,20 @@ impl<P: Provider<Ethereum> + Clone> CctpV2<P> {
         let max_fee = self.transfer_mode.max_fee();
         let min_finality_threshold = self.transfer_mode.finality_threshold().as_u32();
 
-        let tx_request = match self.transfer_mode.hook_data() {
-            Some(hook_data) => token_messenger.deposit_for_burn_with_hooks_transaction(
+        // Match the enum variants directly: `TransferMode` is `#[non_exhaustive]`
+        // for external callers, but exhaustiveness still applies in-crate, so a
+        // new variant forces a compile error here until the wire shape is
+        // decided.
+        let tx_request = match &self.transfer_mode {
+            TransferMode::Standard => token_messenger.deposit_for_burn_transaction(
+                from,
+                self.recipient,
+                destination_domain,
+                token_address,
+                amount,
+                min_finality_threshold,
+            ),
+            TransferMode::Fast { .. } => token_messenger.deposit_for_burn_fast_transaction(
                 from,
                 self.recipient,
                 destination_domain,
@@ -600,10 +612,10 @@ impl<P: Provider<Ethereum> + Clone> CctpV2<P> {
                 amount,
                 max_fee,
                 min_finality_threshold,
-                hook_data.clone(),
             ),
-            None if self.transfer_mode.is_fast() => token_messenger
-                .deposit_for_burn_fast_transaction(
+            TransferMode::StandardWithHook { hook_data }
+            | TransferMode::FastWithHook { hook_data, .. } => token_messenger
+                .deposit_for_burn_with_hooks_transaction(
                     from,
                     self.recipient,
                     destination_domain,
@@ -611,15 +623,8 @@ impl<P: Provider<Ethereum> + Clone> CctpV2<P> {
                     amount,
                     max_fee,
                     min_finality_threshold,
+                    hook_data.clone(),
                 ),
-            None => token_messenger.deposit_for_burn_transaction(
-                from,
-                self.recipient,
-                destination_domain,
-                token_address,
-                amount,
-                min_finality_threshold,
-            ),
         };
 
         info!(
@@ -1987,11 +1992,11 @@ mod tests {
         //! Issue #229: the existing fast-with-hook wire-shape test
         //! (`test_v2_fast_with_hook_calldata_carries_fast_finality_and_max_fee`)
         //! builds a `TokenMessengerV2Contract` directly and never exercises
-        //! the `match self.transfer_mode.hook_data()` arm inside `burn()`
-        //! itself (`src/bridge/v2.rs:594-621`). That dispatch was the home
-        //! of the issue #218 bug — a future refactor that re-orders the
-        //! arms could silently re-introduce the same defect with every
-        //! accessor-level test still green.
+        //! the `match &self.transfer_mode` dispatch inside `burn()` itself
+        //! (`src/bridge/v2.rs:598-628`). That dispatch was the home of the
+        //! issue #218 bug — a future refactor that rewires an arm to the
+        //! wrong contract method could silently re-introduce the same
+        //! defect with every accessor-level test still green.
         //!
         //! The tests below drive `bridge.burn(amount, from, token).await`
         //! against a capturing in-process JSON-RPC transport, then decode


### PR DESCRIPTION
## Summary

Dispatch v2 burns by matching `TransferMode` variants directly so a
new variant forces a compile error in `burn()` until its wire shape is
decided, instead of silently flowing through the `Option<&Bytes>`
fall-through to `depositForBurn` with whatever finality / fee semantics
the new variant happens to carry. Closes #223.

## What's in the diff

- `src/bridge/v2.rs` — replace `match self.transfer_mode.hook_data()` +
  `is_fast()` guard with a direct `match &self.transfer_mode { ... }`
  over the four current variants. The `StandardWithHook` and
  `FastWithHook` arms share a single body via an or-pattern that binds
  `hook_data`; routing and wire shape across all four variants are
  bit-for-bit identical to the prior dispatch.
- `src/bridge/v2.rs` — refresh the `burn_dispatch_wire` module doc to
  reference the new match shape and the post-refactor line range.

## Acceptance check (from #223)

- [x] `max_fee` and `min_finality_threshold` remain hoisted into locals
      above the match (issue #218's structural defense).
- [x] Dispatch matches `&self.transfer_mode` directly rather than
      `self.transfer_mode.hook_data()` / `is_fast()`.
- [x] A new `TransferMode` variant would now fail to compile inside
      `burn()` (in-crate exhaustiveness applies even with
      `#[non_exhaustive]`).
- [x] Wire shape for each existing variant unchanged — covered by the
      existing `burn_dispatch_wire` calldata-capturing tests.

## Test plan

- [x] `cargo nextest run -p cctp-rs --lib --bins --all-features` — 203/203 pass
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --check` clean