### PR TITLE
refactor: catch new TransferMode variants in is_fast and has_hook

### DIFF
--- a/src/bridge/transfer_mode.rs
+++ b/src/bridge/transfer_mode.rs
@@ -105,17 +105,20 @@ impl TransferMode {
     #[inline]
     #[must_use]
     pub const fn is_fast(&self) -> bool {
-        matches!(self, Self::Fast { .. } | Self::FastWithHook { .. })
+        match self {
+            Self::Fast { .. } | Self::FastWithHook { .. } => true,
+            Self::Standard | Self::StandardWithHook { .. } => false,
+        }
     }
 
     /// Returns `true` when the mode carries hook data.
     #[inline]
     #[must_use]
     pub const fn has_hook(&self) -> bool {
-        matches!(
-            self,
-            Self::StandardWithHook { .. } | Self::FastWithHook { .. }
-        )
+        match self {
+            Self::StandardWithHook { .. } | Self::FastWithHook { .. } => true,
+            Self::Standard | Self::Fast { .. } => false,
+        }
     }
 
     /// Returns the fast-transfer fee cap.


### PR DESCRIPTION
## Summary

`TransferMode::is_fast` and `TransferMode::has_hook` were implemented with
`matches!`, which silently returns `false` for any variant not listed in
the pattern. A future fast-flavored or hooked variant added without
touching these predicates would degrade `CctpV2::transfer` (standard
polling instead of fast), `wait_for_receive` (standard chain confirmation
intervals), and `CctpV2::max_fee` (`None` returned for a real fee) — none
of which would fail a test or a build. Closes #233.

## What's in the diff

- `src/bridge/transfer_mode.rs:107-122` — both predicates now `match self`
  exhaustively, listing every current variant on either the `true` or
  `false` arm. Adding a fifth `TransferMode` variant becomes a compile
  error in each predicate until the contributor explicitly classifies it.

No behavior change for the four existing variants: the arms map
one-to-one to the previous `matches!` patterns.

## Acceptance check (from #233)

- [x] `is_fast()` rewritten as exhaustive `match` with every variant
  listed on the `true` or `false` arm.
- [x] `has_hook()` rewritten the same way.
- [x] No behavior change at the three downstream off-chain dispatch
  sites (`v2.rs:197`, `v2.rs:827`, `v2.rs:1189`) — they still call the
  same predicates with the same returns for the four current variants;
  the only change is that a future fifth variant now forces an explicit
  decision at compile time.

## Test plan

- [x] `cargo nextest run -p cctp-rs --lib --bins --all-features` — 203/203 pass
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Existing predicate tests (`transfer_mode.rs:159-199`) cover all
  four current variants for both predicates and continue to pass.