### PR TITLE
docs: clarify v2 bridge sdk vs protocol parser coverage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,9 +5,24 @@ agent-facing file; `CLAUDE.md` points here.
 
 ## What this crate is
 
-A Rust SDK for Circle's Cross-Chain Transfer Protocol (CCTP), bridging USDC
-across 26+ EVM chains. Supports both CCTP v1 (legacy, 7 chains) and v2 (current,
-fast transfers with sub-30s settlement).
+A Rust SDK for Circle's Cross-Chain Transfer Protocol (CCTP) with two
+layers that have different coverage:
+
+- **Bridge SDK** (`CctpV2Bridge`, `Cctp`, `CctpV1` / `CctpV2` traits) —
+  burns USDC and relays attestations end-to-end. Source/destination
+  chains must return `true` from `NamedChain::supports_cctp_v2()`
+  (v2) or `CctpV1::is_supported()` (v1). Current coverage: 10
+  v2-capable chain families (7 v1 chain families plus Linea, Sonic,
+  Sei) with their testnets.
+- **Protocol parser** (`DomainId`, `ParsedV2Message`,
+  `ParsedV2MessageSummary`) — recognizes all 21 CCTP v2 domain IDs
+  Circle has announced, including non-EVM domains (Solana, Starknet
+  Testnet). Parsing is independent of whether the bridge SDK can
+  route to or from a given domain; see the README's "Protocol parser
+  — additional domains" section for the parse-only list.
+
+Supports both CCTP v1 (legacy) and v2 (current, fast transfers with
+sub-30s settlement).
 
 ## When to use what
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `self.transfer_mode.finality_threshold().as_u32()` call and
   extends the issue #218 structural defense to all four
   `TransferMode` variants. Tracks issue #224.
+- README and AGENTS.md now distinguish the bridge SDK's supported
+  chains (the set where `NamedChain::supports_cctp_v2()` returns
+  `true`) from the broader set of CCTP v2 domain IDs that the
+  protocol parser can decode. The previous "26+ networks" claim
+  conflated protocol parsing reach with bridge SDK reach; the
+  bridge SDK currently routes 10 v2-capable chain families with
+  testnets, while the parser recognizes all 21 announced domains
+  including non-EVM ones. Tracks issue #216.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A production-ready Rust implementation of Circle's Cross-Chain Transfer Protocol
 ## Features
 
 - 🚀 **Type-safe** contract interactions using Alloy
-- 🔄 **Multi-chain support** for 26+ mainnet and testnet networks
+- 🔄 **Bridge SDK** for 10 v2-capable EVM mainnet chains plus 6 USDC testnets; **protocol parser** recognizes all 21 CCTP v2 domain IDs (including non-EVM domains such as Solana and Starknet Testnet)
 - 📦 **Builder pattern** for intuitive API usage
 - ⚡ **CCTP v2 support** with fast transfers (<30s settlement)
 - 🤝 **Relayer-aware** APIs for permissionless v2 relay handling
@@ -21,7 +21,22 @@ A production-ready Rust implementation of Circle's Cross-Chain Transfer Protocol
 
 ## Supported Chains
 
-### CCTP v2 (Current)
+cctp-rs has two layers with different coverage. Read both before
+choosing an integration path.
+
+- **Bridge SDK** — `CctpV2Bridge`, `Cctp`, and the `CctpV1` / `CctpV2`
+  traits on `alloy_chains::NamedChain` can burn USDC and relay
+  attestations end-to-end for the chains listed below. These are the
+  chains where `NamedChain::supports_cctp_v2()` returns `true`.
+- **Protocol parser** — `ParsedV2Message`, `ParsedV2MessageSummary`,
+  and the `DomainId` enum recognize every CCTP v2 domain ID Circle has
+  announced (21 at time of writing), including non-EVM domains.
+  Parsing a domain is independent of whether the bridge SDK can route
+  to or from it.
+
+### Bridge SDK — supported chains
+
+Chains returning `true` from `NamedChain::supports_cctp_v2()`:
 
 #### Mainnet
 
@@ -33,9 +48,28 @@ A production-ready Rust implementation of Circle's Cross-Chain Transfer Protocol
 - Sepolia, Arbitrum Sepolia, Base Sepolia, Optimism Sepolia
 - Avalanche Fuji, Polygon Amoy
 
+### Protocol parser — additional domains
+
+`DomainId` and `ParsedV2MessageSummary` recognize the following CCTP
+v2 domains, but the bridge SDK does **not** currently accept them as
+source or destination — `NamedChain::supports_cctp_v2()` returns
+`false` and the bridge builder will reject them:
+
+- Solana (5, non-EVM), Codex (12), World Chain (14), Monad (15),
+  BNB Smart Chain (17), XDC (18), HyperEVM (19), Ink (21), Plume (22),
+  Starknet Testnet (25, non-EVM), Arc Testnet (26)
+
+Use this list when you need to *inspect* messages crossing these
+domains (for indexing, analytics, or wallet UIs) without routing
+through them. To extend bridge SDK support to one of these domains,
+follow [AGENTS.md → Adding chain support](AGENTS.md#adding-chain-support).
+
 ### CCTP v1 (Legacy)
 
-Also supported for backwards compatibility
+The original v1 chain families (Ethereum, Arbitrum, Base, Optimism,
+Avalanche, Polygon, Unichain) and the six USDC testnets above remain
+supported through `Cctp` and the `CctpV1` trait for backwards
+compatibility. v1 has no Unichain testnet entry.
 
 ## Quick Start
 


### PR DESCRIPTION
## Summary

`README.md` and `AGENTS.md` both advertised "26+ networks" / "26+ EVM
chains" while the bridge SDK only routes ~10 chain families through
`NamedChain::supports_cctp_v2`. The number came from protocol-layer
domain ID coverage and applied to message parsing, not bridging — but
the docs never said so. This PR splits the two layers in the docs so
users picking up the crate can tell which set they're working against
before reaching the bridge builder.

Closes #216.

## What's in the diff

- `README.md`
  - Features bullet rewritten: explicit "10 v2-capable EVM mainnet
    chains plus 6 USDC testnets" for the bridge SDK, "21 CCTP v2
    domain IDs (including non-EVM)" for the protocol parser.
  - "Supported Chains" section gains an introductory split between
    bridge SDK and protocol parser, a parse-only list naming each
    domain (Solana, Codex, World Chain, Monad, BNB Smart Chain, XDC,
    HyperEVM, Ink, Plume, Starknet Testnet, Arc Testnet) with its
    domain ID, and a pointer to `AGENTS.md → Adding chain support`.
  - "CCTP v1 (Legacy)" line names the chain families and notes that
    v1 has no Unichain testnet entry.
- `AGENTS.md`
  - "What this crate is" replaced with the same two-layer model.
- `CHANGELOG.md`
  - Entry under `[Unreleased] → Changed` tracking issue #216.

## Acceptance check (from #216)

- [x] Split docs into protocol domain coverage and bridge SDK
      supported chains — bridge SDK list is anchored to the boolean
      result of `NamedChain::supports_cctp_v2()`; protocol parser
      list is the remainder of `DomainId`.
- [x] State which domains can be parsed but not currently bridged
      through `NamedChain` — enumerated by name and ID under the
      "Protocol parser — additional domains" subsection.
- [x] Keep the README support matrix aligned with `supports_cctp_v2`
      tests — the "Bridge SDK — supported chains" mainnet + testnet
      bullets list exactly the variants that
      `NamedChain::supports_cctp_v2()` matches against in
      `src/chain/v2.rs:108-132`.

## Test plan

- [x] `cargo fmt --all -- --check` clean (no Rust touched, but
      verified anyway).
- [N/A] `cargo clippy` / `cargo nextest` — diff is markdown-only
      across three existing files (`README.md`, `AGENTS.md`,
      `CHANGELOG.md`); none are wired into doctests via
      `include_str!`. CI runs the full gate.
- [ ] Manual: skim the rendered README on the PR page to confirm the
      table-of-contents-style headings render correctly.
