### PR TITLE
docs: remind contributors to update doc counts when adding chain support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,6 +129,21 @@ details.
 2. Add the domain ID to `src/protocol/domain_id.rs`.
 3. Implement the trait in `src/chain/config.rs` (v1) or `src/chain/v2.rs` (v2).
 4. Add confirmation times for fast and standard v2 transfers.
+5. Update the prose counts and chain lists in `README.md` and
+   `AGENTS.md` so the docs stay in sync with what the parser and
+   bridge actually cover:
+   - Every new `DomainId` variant bumps the v2 domain ID count
+     quoted in both files ("all 21 CCTP v2 domain IDs").
+   - If `NamedChain::supports_cctp_v2()` returns `true` for the new
+     chain, bump the v2-capable chain family count in this file
+     (currently "10 v2-capable chain families (7 v1 chain families
+     plus …)") and the bridge SDK mainnet/testnet count in the
+     README's "Features" line, then add the chain to the
+     "Mainnet" or "Testnet" list under `Bridge SDK — supported
+     chains`.
+   - If the new domain is parse-only (no `supports_cctp_v2()` entry),
+     add it to the README's `Protocol parser — additional domains`
+     list instead.
 
 ## Security and configuration
 


### PR DESCRIPTION
## Summary

Adds a fifth step to `AGENTS.md → Adding chain support` reminding
contributors to update the prose counts and chain lists in
`README.md` and `AGENTS.md` whenever a new `DomainId` variant lands
or `supports_cctp_v2()` is extended to a new chain. Without this,
the docs drift silently (e.g. the README claims "21 CCTP v2 domain
IDs" while the parser recognizes 22). Closes #237.

## What's in the diff

- `AGENTS.md` — new step 5 under `Adding chain support`, with three
  sub-bullets covering the v2 domain ID count, the v2-capable chain
  family count + README mainnet/testnet count for bridge-capable
  chains, and the parse-only chain list for `DomainId`-only
  additions. Quotes current literal strings ("all 21 CCTP v2 domain
  IDs", "10 v2-capable chain families …") so the contributor has
  greppable anchors.

## Acceptance check (from #237)

- [x] AGENTS.md → Adding chain support names the doc counts that
  must move when a new domain or chain is added.
- [x] Lightweight checklist form rather than templated derived text
  (the issue's suggested starting point — easier to read, and the
  prose stays natural).

## Test plan

- [x] Heading references (`Bridge SDK — supported chains`,
  `Protocol parser — additional domains`) verified to match
  current README.md.
- [x] Quoted strings (`"all 21 CCTP v2 domain IDs"`,
  `"10 v2-capable chain families (7 v1 chain families plus …)"`)
  verified to match current AGENTS.md/README.md so contributors can
  grep for them.
- [N/A] No code changed — `cargo fmt`, `cargo clippy`, `cargo nextest`
  not applicable.