### PR TITLE
refactor: distinguish receive-confirmation timeouts from attestation timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   authoritative source of truth for non-EVM domains such as
   `DomainId::Solana` and `DomainId::StarknetTestnet`. Tracks issue
   #219.
+- New `CctpError::ReceiveTimeout` variant, distinct from
+  `CctpError::AttestationTimeout`. Returned by
+  `CctpV2Bridge::wait_for_receive` when polling for destination-chain
+  receipt confirmation exhausts its attempt budget — at that point
+  attestation has already succeeded, so the failure is observing the
+  message as received in time, not waiting on attestation. Both
+  variants continue to satisfy `CctpError::is_timeout()` and therefore
+  `is_transient()`. Tracks issue #217.
 
 ### Changed
 
+- `CctpV2Bridge::wait_for_receive` now returns
+  `CctpError::ReceiveTimeout` instead of `CctpError::AttestationTimeout`
+  when the receive-confirmation polling loop exhausts its attempts.
+  `CctpError` is `#[non_exhaustive]`, so this is not a compile-time
+  break, but downstream code that pattern-matches on
+  `CctpError::AttestationTimeout` to detect a `wait_for_receive`
+  timeout must update its match to cover the new variant (or rely on
+  `is_timeout()` / `is_transient()`, which already include both).
+  Tracks issue #217.
 - **Breaking:** `ParsedV2MessageSummary::sender` and `recipient` are
   now `Option<Address>` instead of `Address`, and `destination_caller`
   is `None` for non-EVM destinations as well as for permissionless

--- a/src/bridge/v2.rs
+++ b/src/bridge/v2.rs
@@ -789,7 +789,10 @@ impl<P: Provider<Ethereum> + Clone> CctpV2<P> {
     /// # Returns
     ///
     /// * `Ok(())` when the message has been received
-    /// * `Err(CctpError::AttestationTimeout)` if max attempts exceeded
+    /// * `Err(CctpError::ReceiveTimeout)` if max attempts exceeded.
+    ///   This is distinct from [`CctpError::AttestationTimeout`] — by
+    ///   the time this method runs, attestation has already succeeded;
+    ///   what timed out is observing the destination-chain receipt.
     /// * `Err(CctpError::InvalidConfig)` if either input is `Some(0)`
     ///
     /// # Example
@@ -870,7 +873,7 @@ impl<P: Provider<Ethereum> + Clone> CctpV2<P> {
             event = "wait_for_receive_timeout"
         );
 
-        Err(CctpError::AttestationTimeout)
+        Err(CctpError::ReceiveTimeout)
     }
 
     /// Attempt to mint, gracefully handling if already relayed
@@ -2211,6 +2214,103 @@ mod tests {
                     );
                 }
             }
+        }
+    }
+
+    mod wait_for_receive_timeout {
+        //! Regression coverage for #217: when polling exhausts the
+        //! attempt budget, `wait_for_receive` must return the receive-
+        //! specific timeout variant. `AttestationTimeout` would be
+        //! misleading — attestation is already complete by the time the
+        //! caller is waiting on the destination receipt.
+        use super::*;
+        use alloy_json_rpc::{RequestPacket, Response, ResponsePacket, ResponsePayload};
+        use alloy_provider::ProviderBuilder;
+        use alloy_rpc_client::RpcClient;
+        use std::sync::{Arc, Mutex};
+        use std::task::{Context, Poll};
+        use tower::Service;
+
+        /// Tower service that responds to every `eth_call` with an ABI-
+        /// encoded `false`, simulating a destination chain that never
+        /// observes the message as received.
+        #[derive(Clone, Default)]
+        struct AlwaysFalseEthCallTransport {
+            call_count: Arc<Mutex<u32>>,
+        }
+
+        impl Service<RequestPacket> for AlwaysFalseEthCallTransport {
+            type Response = ResponsePacket;
+            type Error = alloy_transport::TransportError;
+            type Future = alloy_transport::TransportFut<'static>;
+
+            fn poll_ready(
+                &mut self,
+                _cx: &mut Context<'_>,
+            ) -> Poll<std::result::Result<(), Self::Error>> {
+                Poll::Ready(Ok(()))
+            }
+
+            fn call(&mut self, req: RequestPacket) -> Self::Future {
+                let call_count = self.call_count.clone();
+                Box::pin(async move {
+                    let RequestPacket::Single(req) = req else {
+                        panic!("wait_for_receive does not issue batch requests");
+                    };
+                    let id = req.id().clone();
+                    assert_eq!(
+                        req.method(),
+                        "eth_call",
+                        "wait_for_receive's polling loop only issues eth_call",
+                    );
+                    *call_count.lock().expect("call-count mutex") += 1;
+                    // `is_message_received` calls `usedNonces(bytes32) returns
+                    // (uint256)` and interprets a non-zero return as "received".
+                    // 32 zero bytes decodes to `U256::ZERO`, which the SDK
+                    // maps to "not received" — exactly the state we want to
+                    // pin so the polling loop runs to exhaustion.
+                    let unused_nonce_json =
+                        "\"0x0000000000000000000000000000000000000000000000000000000000000000\"";
+                    let raw =
+                        serde_json::value::RawValue::from_string(unused_nonce_json.to_string())
+                            .expect("static unused-nonce JSON parses");
+                    Ok(ResponsePacket::Single(Response {
+                        id,
+                        payload: ResponsePayload::Success(raw),
+                    }))
+                })
+            }
+        }
+
+        #[tokio::test(flavor = "current_thread", start_paused = true)]
+        async fn returns_receive_timeout_when_polling_exhausts() {
+            let transport = AlwaysFalseEthCallTransport::default();
+            let call_count = transport.call_count.clone();
+            let provider = ProviderBuilder::new()
+                .disable_recommended_fillers()
+                .connect_client(RpcClient::new(transport, true));
+            let bridge = CctpV2::builder()
+                .source_chain(NamedChain::Mainnet)
+                .destination_chain(NamedChain::Linea)
+                .source_provider(provider.clone())
+                .destination_provider(provider)
+                .recipient(Address::ZERO)
+                .build();
+
+            let err = bridge
+                .wait_for_receive(b"any message bytes", Some(3), Some(1))
+                .await
+                .expect_err("polling against a destination that never reports receipt must error");
+
+            assert!(
+                matches!(err, CctpError::ReceiveTimeout),
+                "wait_for_receive must return ReceiveTimeout, not AttestationTimeout: {err:?}",
+            );
+            assert_eq!(
+                *call_count.lock().expect("call-count mutex"),
+                3,
+                "polling must exhaust the configured attempt budget before timing out",
+            );
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -87,6 +87,13 @@ pub enum CctpError {
     #[error("Timeout waiting for attestation")]
     AttestationTimeout,
 
+    /// Polling for destination-chain receipt confirmation exhausted its
+    /// attempt budget. The attestation may already be complete; what
+    /// timed out is observing the message as received on the
+    /// destination chain.
+    #[error("Timeout waiting for destination-chain message receipt")]
+    ReceiveTimeout,
+
     #[error("Invalid URL: {0}")]
     InvalidUrl(#[from] url::ParseError),
 
@@ -173,7 +180,10 @@ impl CctpError {
     ///
     /// Useful for implementing retry logic for transient failures.
     pub fn is_timeout(&self) -> bool {
-        if matches!(self, CctpError::AttestationTimeout) {
+        if matches!(
+            self,
+            CctpError::AttestationTimeout | CctpError::ReceiveTimeout
+        ) {
             return true;
         }
 
@@ -258,8 +268,23 @@ mod tests {
         let err = CctpError::AttestationTimeout;
         assert!(err.is_timeout());
 
+        let err = CctpError::ReceiveTimeout;
+        assert!(err.is_timeout());
+
         let err = CctpError::InvalidConfig("some error".to_string());
         assert!(!err.is_timeout());
+    }
+
+    #[test]
+    fn test_receive_timeout_renders_distinct_message() {
+        assert_eq!(
+            CctpError::ReceiveTimeout.to_string(),
+            "Timeout waiting for destination-chain message receipt",
+        );
+        assert_ne!(
+            CctpError::ReceiveTimeout.to_string(),
+            CctpError::AttestationTimeout.to_string(),
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`CctpV2Bridge::wait_for_receive` previously returned `CctpError::AttestationTimeout` when destination-chain receipt polling exhausted its attempts. That misnamed the failure: by the time `wait_for_receive` runs, attestation has already succeeded, and what timed out is observing the message as received. This change adds a distinct `CctpError::ReceiveTimeout` variant and switches `wait_for_receive` to return it, leaving `AttestationTimeout` only on the paths where attestation polling itself actually times out. Closes #217.

## What's in the diff

- `src/error.rs` — Add `CctpError::ReceiveTimeout` to the `#[non_exhaustive]` enum and broaden `is_timeout()` (and therefore `is_transient()`) to include it.
- `src/bridge/v2.rs` — `wait_for_receive` now returns `CctpError::ReceiveTimeout` on polling exhaustion. Docstring updated to call out the distinction from `AttestationTimeout`. `get_attestation` paths in v1 and v2 still return `AttestationTimeout` (unchanged) — they're the ones where attestation polling actually exhausts.
- New regression test `wait_for_receive_timeout::returns_receive_timeout_when_polling_exhausts` drives `wait_for_receive` against an in-process tower transport that responds to every `eth_call` with a zero `usedNonces`, asserts the polling budget is fully consumed, and pins the returned variant to `ReceiveTimeout`. Uses `start_paused = true` for deterministic timing.
- New unit tests cover `is_timeout()` recognizing the new variant and the distinct `Display` rendering.
- `CHANGELOG.md` documents the new variant and the behavior change.

## Acceptance check (from #217)

- [x] Distinct error variant added — `CctpError::ReceiveTimeout`.
- [x] `AttestationTimeout` preserved only where attestation polling actually timed out — verified by inspection; the only remaining return sites are `src/bridge/v2.rs:541` and `src/bridge/cctp.rs:378`, both inside `get_attestation` polling loops.
- [x] Test that `wait_for_receive` reports the receive-specific timeout — `bridge::v2::tests::wait_for_receive_timeout::returns_receive_timeout_when_polling_exhausts`.

## Test plan

- [x] `cargo nextest run --workspace --all-features` — 217/217 pass (208 lib + 9 integration).
- [x] `cargo test --workspace --all-features --doc` — 28/28 pass.
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean.
- [x] `cargo fmt --check` clean.

## Notes for reviewers

- `CctpError` is `#[non_exhaustive]`, so adding a variant is not a compile-time SemVer break. The behavior change of `wait_for_receive` returning a different variant on the existing exhaustion path is documented in `CHANGELOG.md` under both `### Added` and `### Changed`.
- A pre-existing observability gap was surfaced during review (`wait_for_receive_timeout` does not call `spans::record_error_with_context(...)` the way `get_attestation` does for `AttestationTimeout`). Filed separately rather than bundled in.