### PR TITLE
feat: surface receive-confirmation timeouts in OTel traces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   message as received in time, not waiting on attestation. Both
   variants continue to satisfy `CctpError::is_timeout()` and therefore
   `is_transient()`. Tracks issue #217.
+- New `cctp_rs.wait_for_receive` OpenTelemetry span emitted around
+  `CctpV2Bridge::wait_for_receive`'s polling loop, plus a public
+  `spans::wait_for_receive` constructor. On polling exhaustion the
+  span records `error.type = "ReceiveTimeout"`, making Tempo/Jaeger
+  queries like `{ span.error.type = "ReceiveTimeout" }` count
+  receive-side timeouts separately from attestation-side ones. The
+  existing `wait_for_receive_timeout` log event also gains an
+  `error_type = "ReceiveTimeout"` field for log-stream parity with
+  `attestation_timeout`. Tracks issue #240.
 
 ### Changed
 

--- a/src/bridge/v2.rs
+++ b/src/bridge/v2.rs
@@ -838,42 +838,65 @@ impl<P: Provider<Ethereum> + Clone> CctpV2<P> {
             }
         });
 
-        info!(
-            max_attempts = max_attempts,
-            poll_interval_secs = poll_interval,
-            fast_transfer = self.transfer_mode.is_fast(),
-            version = "v2",
-            event = "wait_for_receive_started"
+        let message_hash: FixedBytes<32> = alloy_primitives::keccak256(message);
+        let span = spans::wait_for_receive(
+            &message_hash,
+            &self.source_chain,
+            &self.destination_chain,
+            max_attempts,
+            poll_interval,
         );
 
-        for attempt in 1..=max_attempts {
-            if self.is_message_received(message).await? {
-                info!(
-                    attempt = attempt,
-                    version = "v2",
-                    event = "message_received_confirmed"
-                );
-                return Ok(());
-            }
-
-            debug!(
-                attempt = attempt,
+        async move {
+            info!(
                 max_attempts = max_attempts,
+                poll_interval_secs = poll_interval,
+                fast_transfer = self.transfer_mode.is_fast(),
                 version = "v2",
-                event = "message_not_yet_received"
+                event = "wait_for_receive_started"
             );
 
-            sleep(Duration::from_secs(poll_interval)).await;
+            for attempt in 1..=max_attempts {
+                if self.is_message_received(message).await? {
+                    info!(
+                        attempt = attempt,
+                        version = "v2",
+                        event = "message_received_confirmed"
+                    );
+                    return Ok(());
+                }
+
+                debug!(
+                    attempt = attempt,
+                    max_attempts = max_attempts,
+                    version = "v2",
+                    event = "message_not_yet_received"
+                );
+
+                sleep(Duration::from_secs(poll_interval)).await;
+            }
+
+            spans::record_error_with_context(
+                "ReceiveTimeout",
+                &format!(
+                    "wait_for_receive polling timed out after {max_attempts} attempts"
+                ),
+                Some(&format!(
+                    "Poll interval: {poll_interval} seconds; destination chain never reported receipt"
+                )),
+            );
+            error!(
+                max_attempts = max_attempts,
+                poll_interval_secs = poll_interval,
+                version = "v2",
+                error_type = "ReceiveTimeout",
+                event = "wait_for_receive_timeout"
+            );
+
+            Err(CctpError::ReceiveTimeout)
         }
-
-        error!(
-            max_attempts = max_attempts,
-            poll_interval_secs = poll_interval,
-            version = "v2",
-            event = "wait_for_receive_timeout"
-        );
-
-        Err(CctpError::ReceiveTimeout)
+        .instrument(span)
+        .await
     }
 
     /// Attempt to mint, gracefully handling if already relayed

--- a/src/spans.rs
+++ b/src/spans.rs
@@ -232,6 +232,37 @@ pub fn receive_message(
     )
 }
 
+/// Create span for polling the destination chain until a message is received.
+///
+/// Declares the four error-attribute fields so that
+/// [`record_error_with_context`] writes (notably the `ReceiveTimeout`
+/// variant emitted on polling exhaustion) materialise on this span and
+/// become queryable via `{ span.error.type = "ReceiveTimeout" }` in
+/// Tempo/Jaeger.
+///
+/// Parent: Top-level bridge operation span
+/// Children: `is_message_received` RPC calls (from alloy instrumentation)
+pub fn wait_for_receive(
+    message_hash: &FixedBytes<32>,
+    source_chain: &NamedChain,
+    destination_chain: &NamedChain,
+    max_attempts: u32,
+    poll_interval_secs: u64,
+) -> Span {
+    tracing::info_span!(
+        "cctp_rs.wait_for_receive",
+        message_hash = %message_hash,
+        source_chain = %source_chain,
+        destination_chain = %destination_chain,
+        max_attempts = max_attempts,
+        poll_interval_secs = poll_interval_secs,
+        error.type = tracing::field::Empty,
+        error.message = tracing::field::Empty,
+        error.context = tracing::field::Empty,
+        otel.status_code = "OK",
+    )
+}
+
 /// Create span for HTTP request to Circle API.
 ///
 /// Parent: `get_attestation` or other API operation

--- a/tests/inner_span_error_attributes.rs
+++ b/tests/inner_span_error_attributes.rs
@@ -23,12 +23,16 @@
 //! and asserts that the expected field landed on the expected span.
 
 use std::sync::{Arc, Mutex};
+use std::task::Poll;
 
 use alloy_chains::NamedChain;
+use alloy_json_rpc::{RequestPacket, Response, ResponsePacket, ResponsePayload};
 use alloy_network::Ethereum;
 use alloy_primitives::{Address, FixedBytes};
 use alloy_provider::{Provider, ProviderBuilder};
+use alloy_rpc_client::RpcClient;
 use cctp_rs::{Cctp, CctpV2Bridge, PollingConfig};
+use tower::Service;
 use tracing::field::{Field, Visit};
 use tracing::span::Record;
 use tracing_subscriber::layer::{Context, SubscriberExt};
@@ -468,6 +472,88 @@ async fn v2_process_response_span_records_message_data_missing() {
     assert_field_recorded(
         &captured,
         "cctp_rs.process_attestation_response",
+        "otel.status_code",
+        "ERROR",
+    );
+}
+
+/// Tower service that responds to every `eth_call` with an ABI-encoded
+/// `false`, simulating a destination chain that never observes the
+/// message as received. Lets `wait_for_receive` polling exhaust its
+/// attempt budget so the `ReceiveTimeout` branch fires.
+#[derive(Clone, Default)]
+struct AlwaysFalseEthCallTransport;
+
+impl Service<RequestPacket> for AlwaysFalseEthCallTransport {
+    type Response = ResponsePacket;
+    type Error = alloy_transport::TransportError;
+    type Future = alloy_transport::TransportFut<'static>;
+
+    fn poll_ready(
+        &mut self,
+        _cx: &mut std::task::Context<'_>,
+    ) -> Poll<std::result::Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn call(&mut self, req: RequestPacket) -> Self::Future {
+        Box::pin(async move {
+            let RequestPacket::Single(req) = req else {
+                panic!("wait_for_receive does not issue batch requests");
+            };
+            let id = req.id().clone();
+            assert_eq!(
+                req.method(),
+                "eth_call",
+                "wait_for_receive's polling loop only issues eth_call",
+            );
+            // 32 zero bytes decode to `U256::ZERO`, which `is_message_received`
+            // interprets as "not received".
+            let unused_nonce_json =
+                "\"0x0000000000000000000000000000000000000000000000000000000000000000\"";
+            let raw = serde_json::value::RawValue::from_string(unused_nonce_json.to_string())
+                .expect("static unused-nonce JSON parses");
+            Ok(ResponsePacket::Single(Response {
+                id,
+                payload: ResponsePayload::Success(raw),
+            }))
+        })
+    }
+}
+
+#[tokio::test(flavor = "current_thread", start_paused = true)]
+async fn v2_wait_for_receive_span_records_receive_timeout() {
+    let (records, _guard) = install_record_subscriber();
+
+    let provider = ProviderBuilder::new()
+        .disable_recommended_fillers()
+        .connect_client(RpcClient::new(AlwaysFalseEthCallTransport, true));
+    let bridge = CctpV2Bridge::builder()
+        .source_chain(NamedChain::Mainnet)
+        .destination_chain(NamedChain::Linea)
+        .source_provider(provider.clone())
+        .destination_provider(provider)
+        .recipient(Address::ZERO)
+        .build();
+
+    let result = bridge
+        .wait_for_receive(b"any message bytes", Some(3), Some(1))
+        .await;
+    assert!(
+        result.is_err(),
+        "expected wait_for_receive to time out against a destination that never reports receipt"
+    );
+
+    let captured = records.lock().unwrap();
+    assert_field_recorded(
+        &captured,
+        "cctp_rs.wait_for_receive",
+        "error.type",
+        "ReceiveTimeout",
+    );
+    assert_field_recorded(
+        &captured,
+        "cctp_rs.wait_for_receive",
         "otel.status_code",
         "ERROR",
     );


### PR DESCRIPTION
## Summary

`CctpV2::wait_for_receive` now runs inside a `cctp_rs.wait_for_receive`
span that declares the standard error-attribute fields, and records
`error.type = "ReceiveTimeout"` on polling exhaustion. Operators can
now distinguish receive-side timeouts from attestation-side ones in
Tempo/Jaeger via `{ span.error.type = "ReceiveTimeout" }`, instead of
falling back to log-stream search. Closes #240.

## What's in the diff

- `src/spans.rs` — adds the `wait_for_receive(...)` constructor mirroring
  the existing v2 attestation pattern (declares `error.type`,
  `error.message`, `error.context`, `otel.status_code`).
- `src/bridge/v2.rs::wait_for_receive` — computes the message hash,
  builds the span, wraps the polling loop body in
  `async move { ... }.instrument(span).await`, and calls
  `spans::record_error_with_context("ReceiveTimeout", ...)` on the
  timeout path. The existing `wait_for_receive_timeout` log event also
  gains an `error_type` field for log-stream parity with the
  `attestation_timeout` event (issue suggestion 3).
- `tests/inner_span_error_attributes.rs` — adds
  `v2_wait_for_receive_span_records_receive_timeout`, a regression test
  driving the polling loop against an `AlwaysFalseEthCallTransport` and
  asserting the `error.type = "ReceiveTimeout"` and
  `otel.status_code = "ERROR"` fields land on the right span.

## Acceptance check (from #240)

- [x] `spans::wait_for_receive(...)` constructor declares the four
  error-attribute fields.
- [x] `wait_for_receive` body is wrapped with `.instrument(span)`; the
  timeout path calls `spans::record_error_with_context("ReceiveTimeout", ...)`.
- [x] `error_type = "ReceiveTimeout"` field added to the existing
  `error!(event = "wait_for_receive_timeout")` for log-stream parity
  (issue suggestion 3).
- [x] Regression test asserts a `wait_for_receive` exhaustion records
  `error.type = "ReceiveTimeout"` on the right span.

## Test plan

- [x] `cargo nextest run --workspace --all-features` — 218/218 pass
  (including the new `v2_wait_for_receive_span_records_receive_timeout`).
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean.
- [x] `cargo fmt --check` clean.
- [x] Pre-commit `/code-review` returned no blockers.

## Notes

- The polling loop's existing pre-PR shape (issuing one final `sleep`
  on the exhausting iteration before returning `ReceiveTimeout`) is
  preserved as-is. That is a pre-existing pattern shared with the
  attestation loop and outside the observability scope of this issue.
- The implementer choice on shape (issue point 4): the polling loop is
  not folded into a per-attempt child span. The single
  `cctp_rs.wait_for_receive` span suffices for `error.type` queries; a
  per-attempt child span would add cardinality without adding
  filterable attributes for the existing dashboards.