### PR TITLE
refactor: distinguish unsourced fast transfer fees from a confirmed zero

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,7 @@ All exports live in `src/lib.rs` under `pub use`. Quick map for navigation:
 | `PollingConfig` | Attestation polling tuning | `src/bridge/config.rs` |
 | `TokenState`, `batch_token_state` | ERC-20 allowance/balance helpers | `src/bridge/` |
 | `CctpV1`, `CctpV2` traits | Chain config on `NamedChain` | `src/chain/config.rs`, `src/chain/v2.rs` |
+| `FastTransferFee` | `Known(u32)` / `Unknown` — fast-transfer fee status per chain | `src/chain/v2.rs` |
 | `CCTP_V2_*_MAINNET/TESTNET` | Unified v2 contract addresses | `src/chain/addresses.rs` |
 | `TokenMessengerContract`, `MessageTransmitterContract` | V1 contract wrappers | `src/contracts/` |
 | `TokenMessengerV2Contract`, `MessageTransmitterV2Contract` | V2 contract wrappers | `src/contracts/v2/` |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   bridge SDK currently routes 10 v2-capable chain families with
   testnets, while the parser recognizes all 21 announced domains
   including non-EVM ones. Tracks issue #216.
+- **Breaking:** `CctpV2::fast_transfer_fee_bps` now returns
+  `Result<FastTransferFee>` instead of `Result<Option<u32>>`, where
+  `FastTransferFee` is a new public enum with `Known(u32)` and
+  `Unknown` variants. Previous versions returned `Ok(Some(0))` for
+  every v2-capable chain because per-chain fees had not yet been
+  sourced — making unknown external protocol data look like a
+  confirmed zero fee to downstream consumers. Until each chain's
+  fee is sourced against an authoritative Circle reference, every
+  chain now reports `FastTransferFee::Unknown`. Callers handling
+  user funds should fetch the live fee rather than treating
+  `Unknown` as zero. The enum is `#[non_exhaustive]` so future
+  variants (e.g. a sourced-with-provenance form) can be added
+  without another major break, and the trait method carries
+  `#[must_use]` to surface accidental drops. Tracks issue #215.
 
 ### Fixed
 

--- a/examples/v2_integration_validation.rs
+++ b/examples/v2_integration_validation.rs
@@ -13,7 +13,7 @@
 use alloy_chains::NamedChain;
 use alloy_primitives::{Address, Bytes, U256};
 use alloy_provider::ProviderBuilder;
-use cctp_rs::{CctpV2, CctpV2Bridge, DomainId, TransferMode};
+use cctp_rs::{CctpV2, CctpV2Bridge, DomainId, FastTransferFee, TransferMode};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -485,11 +485,12 @@ fn validate_fast_transfer_support() -> Result<(), Box<dyn std::error::Error>> {
         print!("   ✓ {:<20} Fast: Yes  ", format!("{chain}"));
 
         match fee_bps {
-            Some(bps) => {
+            FastTransferFee::Known(bps) => {
                 assert!(bps <= 14, "Fee should be 0-14 bps, got {bps}");
                 println!("Fee: {bps} bps");
             }
-            None => println!("Fee: Free (0 bps)"),
+            FastTransferFee::Unknown => println!("Fee: unknown (not sourced)"),
+            _ => println!("Fee: unrecognized FastTransferFee variant"),
         }
     }
 

--- a/src/chain/mod.rs
+++ b/src/chain/mod.rs
@@ -14,4 +14,4 @@ mod config;
 mod v2;
 
 pub use config::CctpV1;
-pub use v2::CctpV2;
+pub use v2::{CctpV2, FastTransferFee};

--- a/src/chain/v2.rs
+++ b/src/chain/v2.rs
@@ -325,16 +325,31 @@ mod tests {
     }
 
     #[rstest]
+    // v1 mainnets that also support v2
     #[case(NamedChain::Mainnet)]
     #[case(NamedChain::Arbitrum)]
     #[case(NamedChain::Base)]
+    #[case(NamedChain::Optimism)]
+    #[case(NamedChain::Avalanche)]
+    #[case(NamedChain::Polygon)]
+    #[case(NamedChain::Unichain)]
+    // v2-only mainnets
     #[case(NamedChain::Linea)]
     #[case(NamedChain::Sonic)]
     #[case(NamedChain::Sei)]
+    // v1 testnets that also support v2
+    #[case(NamedChain::Sepolia)]
+    #[case(NamedChain::ArbitrumSepolia)]
+    #[case(NamedChain::BaseSepolia)]
+    #[case(NamedChain::OptimismSepolia)]
+    #[case(NamedChain::AvalancheFuji)]
+    #[case(NamedChain::PolygonAmoy)]
     fn fast_transfer_fee_is_unknown_until_sourced(#[case] chain: NamedChain) {
         // Per-chain values are not sourced yet, so every supported v2
         // chain must report Unknown — never a placeholder Known(0)
-        // that would look like a confirmed fee to callers.
+        // that would look like a confirmed fee to callers. Exhaustive
+        // over every variant matched by `supports_cctp_v2()` so a
+        // future variant that accidentally returns Err is caught.
         assert_eq!(
             chain.fast_transfer_fee_bps().unwrap(),
             FastTransferFee::Unknown

--- a/src/chain/v2.rs
+++ b/src/chain/v2.rs
@@ -16,6 +16,33 @@ use super::addresses::{
 };
 use crate::{CctpError, DomainId, Result};
 
+/// Fast Transfer fee for a CCTP v2 chain, in basis points.
+///
+/// Circle's documentation states fast transfer fees range from 0 to 14
+/// basis points and are configured per chain. Until a chain's fee has
+/// been confirmed against an authoritative source, this SDK represents
+/// it as [`FastTransferFee::Unknown`] rather than asserting a numeric
+/// value. Callers handling user funds should treat `Unknown` as a
+/// signal to fetch the live fee on-chain or via Circle's APIs before
+/// quoting it as zero.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum FastTransferFee {
+    /// Fee is confirmed at this value in basis points (0-14).
+    ///
+    /// A `Known(0)` is a sourced zero fee, semantically distinct from
+    /// [`FastTransferFee::Unknown`].
+    Known(u32),
+    /// Fee data has not yet been confirmed for this chain.
+    ///
+    /// Callers must not assume zero. Coercing `Unknown` to zero would
+    /// reintroduce the placeholder behavior this enum exists to
+    /// prevent — Circle's published range is 0-14 bps, so a default
+    /// of zero is plausible enough to mask a real fee from downstream
+    /// consumers.
+    Unknown,
+}
+
 /// CCTP v2 chain configuration trait
 ///
 /// Implemented on `alloy_chains::NamedChain` to provide v2-specific
@@ -49,15 +76,21 @@ pub trait CctpV2 {
     /// Fast Transfer enables ~30 second settlement times vs 13-19 minutes.
     fn supports_fast_transfer(&self) -> Result<bool>;
 
-    /// Returns the fast transfer fee in basis points (0-14 bps)
+    /// Reports whether a fast transfer fee has been sourced for this
+    /// chain, and if so its value in basis points.
     ///
-    /// Returns `None` for chains that don't charge fast transfer fees,
-    /// or if the chain doesn't support fast transfer.
+    /// Returns [`FastTransferFee::Unknown`] when the chain's fee has
+    /// not been confirmed against an authoritative source. This is
+    /// the current state for every v2 chain in this SDK — Circle's
+    /// docs name a 0-14 bps range, but per-chain values must be
+    /// sourced before being claimed here. Callers handling user
+    /// funds must not coerce `Unknown` to zero; fetch the live fee
+    /// from Circle or on-chain instead.
     ///
-    /// Fee ranges:
-    /// - 0 bps: Free fast transfer (most chains)
-    /// - 1-14 bps: Small fee for fast settlement
-    fn fast_transfer_fee_bps(&self) -> Result<Option<u32>>;
+    /// Errors if the chain doesn't support CCTP v2.
+    #[must_use = "ignoring the fast transfer fee can mis-quote a transfer; \
+                  Unknown must not be coerced to zero"]
+    fn fast_transfer_fee_bps(&self) -> Result<FastTransferFee>;
 
     /// Returns the `TokenMessengerV2` contract address for this chain
     ///
@@ -140,15 +173,15 @@ impl CctpV2 for NamedChain {
         Ok(true)
     }
 
-    fn fast_transfer_fee_bps(&self) -> Result<Option<u32>> {
+    fn fast_transfer_fee_bps(&self) -> Result<FastTransferFee> {
         if !self.supports_cctp_v2() {
             return Err(CctpError::UnsupportedChain(*self));
         }
 
-        // Most chains have 0 bps fees (free fast transfer!)
-        // Based on Circle's documentation, fees range from 0-14 bps
-        // TODO: Update with actual fee data per chain when available
-        Ok(Some(0))
+        // Per-chain fees have not been sourced against Circle's
+        // published values; until they are, every chain reports
+        // Unknown rather than a placeholder zero.
+        Ok(FastTransferFee::Unknown)
     }
 
     fn token_messenger_v2_address(&self) -> Result<Address> {
@@ -291,14 +324,34 @@ mod tests {
         assert!(NamedChain::Moonbeam.supports_fast_transfer().is_err());
     }
 
-    #[test]
-    fn test_fast_transfer_fees() {
-        // Currently all chains return 0 bps (placeholder)
+    #[rstest]
+    #[case(NamedChain::Mainnet)]
+    #[case(NamedChain::Arbitrum)]
+    #[case(NamedChain::Base)]
+    #[case(NamedChain::Linea)]
+    #[case(NamedChain::Sonic)]
+    #[case(NamedChain::Sei)]
+    fn fast_transfer_fee_is_unknown_until_sourced(#[case] chain: NamedChain) {
+        // Per-chain values are not sourced yet, so every supported v2
+        // chain must report Unknown — never a placeholder Known(0)
+        // that would look like a confirmed fee to callers.
         assert_eq!(
-            NamedChain::Mainnet.fast_transfer_fee_bps().unwrap(),
-            Some(0)
+            chain.fast_transfer_fee_bps().unwrap(),
+            FastTransferFee::Unknown
         );
-        assert_eq!(NamedChain::Linea.fast_transfer_fee_bps().unwrap(), Some(0));
+    }
+
+    #[test]
+    fn fast_transfer_fee_unknown_is_distinct_from_known_zero() {
+        // Sanity: Known(0) and Unknown are not equal. This is the
+        // invariant issue #215 cared about — a confirmed-zero fee must
+        // not collide with the "we haven't sourced this" state.
+        assert_ne!(FastTransferFee::Known(0), FastTransferFee::Unknown);
+    }
+
+    #[test]
+    fn fast_transfer_fee_errors_for_unsupported_chain() {
+        assert!(NamedChain::Moonbeam.fast_transfer_fee_bps().is_err());
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,7 +159,7 @@ pub use chain::addresses::{
     CCTP_V2_MESSAGE_TRANSMITTER_MAINNET, CCTP_V2_MESSAGE_TRANSMITTER_TESTNET,
     CCTP_V2_TOKEN_MESSENGER_MAINNET, CCTP_V2_TOKEN_MESSENGER_TESTNET,
 };
-pub use chain::{CctpV1, CctpV2};
+pub use chain::{CctpV1, CctpV2, FastTransferFee};
 pub use contracts::{
     erc20::Erc20Contract,
     message_transmitter::{MessageTransmitter, MessageTransmitterContract},


### PR DESCRIPTION
## Summary

`CctpV2::fast_transfer_fee_bps` used to return `Ok(Some(0))` for every
v2-capable chain — a placeholder that looked identical to a confirmed
zero fee to anyone quoting user-facing costs from the SDK. This PR
replaces the return shape with a new `FastTransferFee` enum that
makes the unsourced state explicit, so callers can't accidentally
treat unknown protocol data as a zero. Closes #215.

## What's in the diff

- `src/chain/v2.rs` — new `pub enum FastTransferFee { Known(u32), Unknown }`,
  marked `#[non_exhaustive]` so future provenance/sourced variants
  don't trigger another major break. Trait method changes to
  `Result<FastTransferFee>` and carries `#[must_use]` with guidance
  that `Unknown` must not be coerced to zero. Implementation returns
  `FastTransferFee::Unknown` for every supported v2 chain until
  per-chain values are sourced. Tests updated.
- `src/lib.rs`, `src/chain/mod.rs` — re-export `FastTransferFee` from
  the crate root and the `chain` module.
- `examples/v2_integration_validation.rs` — match on the new enum;
  wildcard arm covers the `#[non_exhaustive]` future-variant case.
- `CHANGELOG.md` — Breaking entry under `[Unreleased]` describing the
  type change, the `#[non_exhaustive]` + `#[must_use]` choices, and
  the migration story for callers.

## Acceptance check (from #215)

- [x] **Return `Ok(None)` until chain-specific fee data is known, or introduce an explicit `Unknown` representation.** — Took the explicit-enum route. `Option<u32>` would have re-overloaded `None` (the previous docstring used `None` to mean "doesn't charge"); the enum lets `Known(0)` and `Unknown` coexist cleanly.
- [x] **If zero is known for a chain, back it with a sourced per-chain table.** — Honored in the negative: no chain has been sourced, so no chain returns `Known(0)`. When the table is populated, individual chains will switch to `Known(n)`; the test `fast_transfer_fee_is_unknown_until_sourced` will fail for that chain and force a paired update.
- [x] **Add tests that distinguish known zero from unknown.** — `fast_transfer_fee_unknown_is_distinct_from_known_zero` asserts `Known(0) != Unknown`; the rstest case covers six chains for the "currently unknown" invariant.

## Test plan

- [x] `cargo nextest run --all-features` — 225/225 pass
- [x] `cargo test --doc --all-features` — 28/28 pass
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo build --example v2_integration_validation` builds

## Follow-up filed

- #242 — Residual "26+ networks" claim in `CctpV2` rustdoc and README contradicts the #216 retraction. Surfaced by /code-review during this PR but standalone; not bundled here.