### PR TITLE
fix: scan all v2 attestation messages instead of only the first

### DIFF
--- a/src/bridge/v2.rs
+++ b/src/bridge/v2.rs
@@ -4,7 +4,9 @@
 
 use crate::error::{AttestationFailureKind, CctpError, Result};
 use crate::protocol::{AttestationBytes, FinalityThreshold};
-use crate::{spans, AttestationStatus, CctpV2 as CctpV2Trait, DomainId, V2AttestationResponse};
+use crate::{
+    spans, AttestationStatus, CctpV2 as CctpV2Trait, DomainId, V2AttestationResponse, V2Message,
+};
 use alloy_chains::NamedChain;
 use alloy_network::Ethereum;
 use alloy_primitives::{hex, Address, Bytes, FixedBytes, TxHash, U256};
@@ -464,54 +466,53 @@ impl<P: Provider<Ethereum> + Clone> CctpV2<P> {
                                 }
                             };
 
-                        // V2 returns an array of messages - get the first one
-                        let message = match v2_response.messages.first() {
-                            Some(msg) => msg,
-                            None => {
-                                debug!(event = "no_messages_in_response");
-                                sleep(Duration::from_secs(poll_interval)).await;
-                                return Ok(None);
-                            }
-                        };
-
-                        match message.status {
-                            AttestationStatus::Complete => {
-                                let attestation_bytes = message
-                                    .attestation
-                                    .as_ref()
-                                    .ok_or_else(super::attestation_data_missing)?
-                                    .to_vec();
-
-                                let message_bytes = message
-                                    .message
-                                    .as_ref()
-                                    .ok_or_else(|| {
-                                        spans::record_error_with_context(
-                                            "MessageDataMissing",
-                                            "Attestation status is complete but message field is null",
-                                            Some("This indicates an unexpected API response format"),
-                                        );
-                                        error!(event = "message_data_missing");
-                                        CctpError::AttestationFailed(
-                                            AttestationFailureKind::MessageMissing,
-                                        )
-                                    })?
-                                    .to_vec();
-
+                        // V2 can return several messages for one transaction. Pick
+                        // the right action by scanning the whole array rather than
+                        // trusting the first entry — the first could be pending or
+                        // failed while a sibling carries usable attestation data.
+                        let message_count = v2_response.messages.len();
+                        match select_v2_attestation(&v2_response.messages) {
+                            V2AttestationOutcome::Ready {
+                                message: message_bytes,
+                                attestation: attestation_bytes,
+                            } => {
                                 info!(
                                     message_length_bytes = message_bytes.len(),
                                     attestation_length_bytes = attestation_bytes.len(),
+                                    message_count = message_count,
                                     version = "v2",
                                     fast_transfer = self.transfer_mode.is_fast(),
                                     event = "attestation_complete"
                                 );
                                 Ok(Some((message_bytes, attestation_bytes)))
                             }
-                            AttestationStatus::Failed => {
+                            V2AttestationOutcome::Failed => {
                                 Err(super::attestation_api_reported_failed())
                             }
-                            AttestationStatus::Pending | AttestationStatus::PendingConfirmations => {
-                                debug!(event = "attestation_pending");
+                            V2AttestationOutcome::AttestationMissing => {
+                                Err(super::attestation_data_missing())
+                            }
+                            V2AttestationOutcome::MessageMissing => {
+                                spans::record_error_with_context(
+                                    "MessageDataMissing",
+                                    "Attestation status is complete but message field is null",
+                                    Some("This indicates an unexpected API response format"),
+                                );
+                                error!(event = "message_data_missing");
+                                Err(CctpError::AttestationFailed(
+                                    AttestationFailureKind::MessageMissing,
+                                ))
+                            }
+                            V2AttestationOutcome::Pending => {
+                                debug!(
+                                    message_count = message_count,
+                                    event = "attestation_pending"
+                                );
+                                sleep(Duration::from_secs(poll_interval)).await;
+                                Ok(None)
+                            }
+                            V2AttestationOutcome::Empty => {
+                                debug!(event = "no_messages_in_response");
                                 sleep(Duration::from_secs(poll_interval)).await;
                                 Ok(None)
                             }
@@ -1335,6 +1336,90 @@ impl<P: Provider<Ethereum> + Clone> CctpBridge for CctpV2<P> {
     }
 }
 
+/// The action a single poll of the v2 attestation API should take, derived
+/// from scanning every message Circle returned for the transaction.
+///
+/// A v2 query is keyed by transaction hash, and one transaction can emit
+/// multiple `MessageSent` events, so the response array may hold a mix of
+/// pending, complete, and failed entries. Selecting on the array as a whole
+/// keeps a usable attestation from being missed because it sat behind a
+/// pending or failed sibling.
+#[derive(Debug, PartialEq, Eq)]
+enum V2AttestationOutcome {
+    /// A complete message carrying both message and attestation bytes.
+    Ready {
+        message: Vec<u8>,
+        attestation: AttestationBytes,
+    },
+    /// No usable message yet, but at least one is still pending — keep polling.
+    Pending,
+    /// A `Complete` message was found but its attestation field was null.
+    AttestationMissing,
+    /// A `Complete` message was found but its message field was null.
+    MessageMissing,
+    /// Every message reported failure and none carried usable data.
+    Failed,
+    /// The response held no messages — keep polling.
+    Empty,
+}
+
+/// Chooses what to do with a v2 attestation response's message array.
+///
+/// Precedence, highest first:
+/// 1. Any `Complete` message with both fields present succeeds, even if a
+///    sibling has failed.
+/// 2. A still-pending message means keep polling — a failed sibling does not
+///    end the transaction while another message may yet complete.
+/// 3. A `Complete` message missing its data is surfaced as a malformed
+///    response (attestation checked before message, matching the prior path).
+/// 4. With nothing pending or usable, an all-failed response fails.
+/// 5. An empty array keeps polling.
+fn select_v2_attestation(messages: &[V2Message]) -> V2AttestationOutcome {
+    if let Some((message, attestation)) = messages.iter().find_map(|message| {
+        if message.status != AttestationStatus::Complete {
+            return None;
+        }
+        Some((
+            message.message.as_ref()?.to_vec(),
+            message.attestation.as_ref()?.to_vec(),
+        ))
+    }) {
+        return V2AttestationOutcome::Ready {
+            message,
+            attestation,
+        };
+    }
+
+    if messages.iter().any(|message| {
+        matches!(
+            message.status,
+            AttestationStatus::Pending | AttestationStatus::PendingConfirmations
+        )
+    }) {
+        return V2AttestationOutcome::Pending;
+    }
+
+    if let Some(message) = messages
+        .iter()
+        .find(|message| message.status == AttestationStatus::Complete)
+    {
+        return if message.attestation.is_none() {
+            V2AttestationOutcome::AttestationMissing
+        } else {
+            V2AttestationOutcome::MessageMissing
+        };
+    }
+
+    if messages
+        .iter()
+        .any(|message| message.status == AttestationStatus::Failed)
+    {
+        return V2AttestationOutcome::Failed;
+    }
+
+    V2AttestationOutcome::Empty
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2014,6 +2099,169 @@ mod tests {
         assert_eq!(bridge.hook_data(), Some(&hook_data));
         assert_eq!(bridge.hook_data().unwrap().len(), 4);
         assert_eq!(bridge.hook_data().unwrap()[0], 0xde);
+    }
+
+    mod select_v2_attestation {
+        //! Unit coverage for the multi-message selection in
+        //! [`super::super::select_v2_attestation`] (issue #213).
+        //!
+        //! V2 polling used to read `messages.first()` and act on that one
+        //! entry's status, so a complete attestation sitting behind a
+        //! pending or failed sibling was either ignored or treated as a
+        //! whole-transaction failure. These tests pin the array-wide
+        //! precedence: a usable complete message wins over anything, a
+        //! pending sibling keeps polling alive, and only an all-failed
+        //! response fails.
+        use super::super::{select_v2_attestation, V2AttestationOutcome};
+        use super::*;
+
+        fn message(
+            status: AttestationStatus,
+            message: Option<&[u8]>,
+            attestation: Option<&[u8]>,
+        ) -> V2Message {
+            V2Message {
+                status,
+                message: message.map(Bytes::copy_from_slice),
+                attestation: attestation.map(Bytes::copy_from_slice),
+            }
+        }
+
+        fn complete(msg: &[u8], attestation: &[u8]) -> V2Message {
+            message(AttestationStatus::Complete, Some(msg), Some(attestation))
+        }
+
+        #[test]
+        fn empty_array_keeps_polling() {
+            assert_eq!(select_v2_attestation(&[]), V2AttestationOutcome::Empty);
+        }
+
+        #[test]
+        fn single_complete_message_is_ready() {
+            let messages = vec![complete(&[0xde, 0xad], &[0xbe, 0xef])];
+            assert_eq!(
+                select_v2_attestation(&messages),
+                V2AttestationOutcome::Ready {
+                    message: vec![0xde, 0xad],
+                    attestation: vec![0xbe, 0xef],
+                }
+            );
+        }
+
+        #[test]
+        fn complete_behind_pending_is_selected() {
+            // The defect: the first entry is pending, the usable attestation
+            // sits second. The old `messages.first()` path would have slept
+            // and kept polling forever even though data was already present.
+            let messages = vec![
+                message(AttestationStatus::Pending, None, None),
+                complete(&[0x01, 0x02], &[0x03, 0x04]),
+            ];
+            assert_eq!(
+                select_v2_attestation(&messages),
+                V2AttestationOutcome::Ready {
+                    message: vec![0x01, 0x02],
+                    attestation: vec![0x03, 0x04],
+                }
+            );
+        }
+
+        #[test]
+        fn complete_behind_failed_is_selected() {
+            // The defect's other half: a failed first entry would have failed
+            // the whole transaction even though a sibling completed.
+            let messages = vec![
+                message(AttestationStatus::Failed, None, None),
+                complete(&[0xaa], &[0xbb]),
+            ];
+            assert_eq!(
+                select_v2_attestation(&messages),
+                V2AttestationOutcome::Ready {
+                    message: vec![0xaa],
+                    attestation: vec![0xbb],
+                }
+            );
+        }
+
+        #[test]
+        fn first_complete_message_wins_when_several_are_ready() {
+            let messages = vec![complete(&[0x11], &[0x22]), complete(&[0x33], &[0x44])];
+            assert_eq!(
+                select_v2_attestation(&messages),
+                V2AttestationOutcome::Ready {
+                    message: vec![0x11],
+                    attestation: vec![0x22],
+                }
+            );
+        }
+
+        #[test]
+        fn pending_sibling_outranks_failed_when_none_complete() {
+            // A failed message must not end the transaction while a sibling
+            // is still pending and might yet complete on a later poll.
+            let messages = vec![
+                message(AttestationStatus::Failed, None, None),
+                message(AttestationStatus::PendingConfirmations, None, None),
+            ];
+            assert_eq!(
+                select_v2_attestation(&messages),
+                V2AttestationOutcome::Pending
+            );
+        }
+
+        #[test]
+        fn all_failed_fails() {
+            let messages = vec![
+                message(AttestationStatus::Failed, None, None),
+                message(AttestationStatus::Failed, None, None),
+            ];
+            assert_eq!(
+                select_v2_attestation(&messages),
+                V2AttestationOutcome::Failed
+            );
+        }
+
+        #[test]
+        fn complete_missing_attestation_reports_attestation_missing() {
+            // No pending sibling, so the malformed complete is surfaced rather
+            // than masked — attestation is checked before message.
+            let messages = vec![message(
+                AttestationStatus::Complete,
+                Some(&[0xde, 0xad]),
+                None,
+            )];
+            assert_eq!(
+                select_v2_attestation(&messages),
+                V2AttestationOutcome::AttestationMissing
+            );
+        }
+
+        #[test]
+        fn complete_missing_message_reports_message_missing() {
+            let messages = vec![message(
+                AttestationStatus::Complete,
+                None,
+                Some(&[0xbe, 0xef]),
+            )];
+            assert_eq!(
+                select_v2_attestation(&messages),
+                V2AttestationOutcome::MessageMissing
+            );
+        }
+
+        #[test]
+        fn pending_outranks_malformed_complete() {
+            // A complete-but-empty entry alongside a pending one keeps polling:
+            // the pending message may resolve into a usable attestation.
+            let messages = vec![
+                message(AttestationStatus::Complete, None, None),
+                message(AttestationStatus::Pending, None, None),
+            ];
+            assert_eq!(
+                select_v2_attestation(&messages),
+                V2AttestationOutcome::Pending
+            );
+        }
     }
 
     mod burn_dispatch_wire {

--- a/tests/v2_multi_message_attestation.rs
+++ b/tests/v2_multi_message_attestation.rs
@@ -1,0 +1,150 @@
+// SPDX-FileCopyrightText: 2025 Semiotic AI, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! End-to-end coverage for v2 attestation polling over multi-message
+//! responses (issue #213).
+//!
+//! A v2 query is keyed by transaction hash, and one transaction can emit
+//! several `MessageSent` events, so Circle's Iris API may return an array
+//! mixing pending, complete, and failed entries. The polling loop used to
+//! read only `messages.first()`, so a usable attestation sitting behind a
+//! pending or failed sibling was ignored or treated as a whole-transaction
+//! failure. These tests drive the real `get_attestation` HTTP/JSON path
+//! against a `wiremock` server to prove the array-wide selection wires
+//! through end to end.
+
+use alloy_chains::NamedChain;
+use alloy_network::Ethereum;
+use alloy_primitives::{Address, FixedBytes};
+use alloy_provider::{Provider, ProviderBuilder};
+use cctp_rs::{CctpV2Bridge, PollingConfig};
+use url::Url;
+use wiremock::matchers::method;
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn dummy_provider() -> impl Provider<Ethereum> + Clone {
+    ProviderBuilder::new().connect_http("http://127.0.0.1:1/".parse().unwrap())
+}
+
+fn bridge(api_override: Url) -> CctpV2Bridge<impl Provider<Ethereum> + Clone> {
+    let provider = dummy_provider();
+    CctpV2Bridge::builder()
+        .source_chain(NamedChain::Mainnet)
+        .destination_chain(NamedChain::Linea)
+        .source_provider(provider.clone())
+        .destination_provider(provider)
+        .recipient(Address::ZERO)
+        .api_url_override(api_override)
+        .build()
+}
+
+#[tokio::test]
+async fn returns_complete_message_behind_failed_sibling() {
+    let server = MockServer::start().await;
+    let message_hex = format!("0x{}", "cc".repeat(228));
+    let attestation_hex = format!("0x{}", "ab".repeat(65));
+    Mock::given(method("GET"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "messages": [
+                { "status": "failed", "message": null, "attestation": null },
+                {
+                    "status": "complete",
+                    "message": message_hex,
+                    "attestation": attestation_hex,
+                }
+            ]
+        })))
+        .mount(&server)
+        .await;
+
+    let api_override = Url::parse(&server.uri()).expect("wiremock URI parses as Url");
+    let (message, attestation) = bridge(api_override)
+        .get_attestation(
+            FixedBytes::from([0xabu8; 32]),
+            PollingConfig::fast_transfer()
+                .with_max_attempts(1)
+                .with_poll_interval_secs(1),
+        )
+        .await
+        .expect("a complete message must be returned despite a failed sibling");
+
+    assert_eq!(message.len(), 228);
+    assert_eq!(attestation.len(), 65);
+}
+
+#[tokio::test]
+async fn polls_until_a_pending_sibling_completes() {
+    // First poll: one failed, one still pending — must keep polling rather
+    // than failing on the failed entry. Second poll: the pending sibling
+    // resolves into a usable attestation.
+    let server = MockServer::start().await;
+    let message_hex = format!("0x{}", "cc".repeat(228));
+    let attestation_hex = format!("0x{}", "ab".repeat(65));
+    Mock::given(method("GET"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "messages": [
+                { "status": "failed", "message": null, "attestation": null },
+                { "status": "pending", "message": null, "attestation": null }
+            ]
+        })))
+        .up_to_n_times(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "messages": [
+                { "status": "failed", "message": null, "attestation": null },
+                {
+                    "status": "complete",
+                    "message": message_hex,
+                    "attestation": attestation_hex,
+                }
+            ]
+        })))
+        .mount(&server)
+        .await;
+
+    let api_override = Url::parse(&server.uri()).expect("wiremock URI parses as Url");
+    let (message, attestation) = bridge(api_override)
+        .get_attestation(
+            FixedBytes::from([0xabu8; 32]),
+            PollingConfig::fast_transfer()
+                .with_max_attempts(3)
+                .with_poll_interval_secs(1),
+        )
+        .await
+        .expect("polling must continue past a failed sibling until the pending one completes");
+
+    assert_eq!(message.len(), 228);
+    assert_eq!(attestation.len(), 65);
+}
+
+#[tokio::test]
+async fn fails_when_every_message_failed() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "messages": [
+                { "status": "failed", "message": null, "attestation": null },
+                { "status": "failed", "message": null, "attestation": null }
+            ]
+        })))
+        .mount(&server)
+        .await;
+
+    let api_override = Url::parse(&server.uri()).expect("wiremock URI parses as Url");
+    let result = bridge(api_override)
+        .get_attestation(
+            FixedBytes::from([0xabu8; 32]),
+            PollingConfig::fast_transfer()
+                .with_max_attempts(1)
+                .with_poll_interval_secs(1),
+        )
+        .await;
+
+    assert!(
+        result.is_err(),
+        "an all-failed response must surface as an error, not a timeout-after-success"
+    );
+}

--- a/tests/v2_multi_message_attestation.rs
+++ b/tests/v2_multi_message_attestation.rs
@@ -18,7 +18,7 @@ use alloy_chains::NamedChain;
 use alloy_network::Ethereum;
 use alloy_primitives::{Address, FixedBytes};
 use alloy_provider::{Provider, ProviderBuilder};
-use cctp_rs::{CctpV2Bridge, PollingConfig};
+use cctp_rs::{AttestationFailureKind, CctpError, CctpV2Bridge, PollingConfig};
 use url::Url;
 use wiremock::matchers::method;
 use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -134,17 +134,24 @@ async fn fails_when_every_message_failed() {
         .await;
 
     let api_override = Url::parse(&server.uri()).expect("wiremock URI parses as Url");
-    let result = bridge(api_override)
+    let err = bridge(api_override)
         .get_attestation(
             FixedBytes::from([0xabu8; 32]),
             PollingConfig::fast_transfer()
                 .with_max_attempts(1)
                 .with_poll_interval_secs(1),
         )
-        .await;
+        .await
+        .expect_err("an all-failed response must surface as a failure, not succeed");
 
+    // The failure must be the API-reported-failed variant, not a timeout:
+    // with nothing pending or usable, the loop should fail on the spot
+    // rather than burn its attempt budget.
     assert!(
-        result.is_err(),
-        "an all-failed response must surface as an error, not a timeout-after-success"
+        matches!(
+            err,
+            CctpError::AttestationFailed(AttestationFailureKind::ApiReportedFailed)
+        ),
+        "expected AttestationFailed(ApiReportedFailed), got {err:?}"
     );
 }


### PR DESCRIPTION
## Summary

V2 attestation polling read `v2_response.messages.first()` and acted on
that single entry. Since a CCTP v2 query is keyed by transaction hash and
one transaction can emit multiple `MessageSent` events, the response array
routinely mixes pending / complete / failed entries. A usable attestation
sitting behind a pending or failed sibling was therefore either ignored
(polling until timeout) or treated as a whole-transaction failure. This PR
scans the entire array with explicit precedence so a complete attestation
is found regardless of its position. `Closes #213.`

## What's in the diff

- `src/bridge/v2.rs`: new pure `select_v2_attestation(&[V2Message]) ->
  V2AttestationOutcome` that decides the per-poll action, and a rewired
  `get_attestation` match that consumes it. Precedence (highest first):
  1. any `Complete` message carrying both `message` and `attestation` →
     succeed, even if a sibling failed;
  2. any `Pending`/`PendingConfirmations` → keep polling (a failed sibling
     does not end the transaction while another may yet complete);
  3. a `Complete` message missing data → same `AttestationMissing` /
     `MessageMissing` errors as the prior single-message path;
  4. nothing pending or usable but something `Failed` → fail;
  5. empty array → keep polling.
- `tests/v2_multi_message_attestation.rs`: wiremock-driven end-to-end
  coverage of the headline scenarios through the real HTTP/JSON path.

## Acceptance check (from #213)

- [x] Scan messages for a `Complete` item with both `message` and
  `attestation` — `select_v2_attestation`'s first pass does exactly this.
- [x] `Failed` treated carefully — a failed entry never ends the
  transaction while a complete or pending sibling exists; only an
  all-failed (nothing pending/usable) response fails.
- [x] Identify the intended message — the API query is per transaction
  hash; the first fully-attested complete message is selected.
- [x] Tests for mixed pending/complete/failed arrays — 10 unit tests over
  the selection function plus 3 wiremock integration tests.
- [x] Spec invariant: `get_attestation` succeeds when the response
  contains at least one complete attested message.

## Test plan

- [x] `cargo nextest run -p cctp-rs --all-features` — 253/253 pass
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt` clean